### PR TITLE
[hermes] Add shared integration helper (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,15 @@ With coverage:
 poetry run pytest --cov=hermes --cov-report=html
 ```
 
+Integration tests that rely on Neo4j + Milvus can be run end-to-end with the shared helper:
+
+```bash
+./scripts/run_integration_stack.sh            # defaults to tests/test_milvus_integration.py -v
+./scripts/run_integration_stack.sh -k milvus  # pass custom pytest args as needed
+```
+
+The script starts the services from `docker-compose.test.yml`, waits for their health checks, streams logs if a container fails, and exports `NEO4J_*` / `MILVUS_*` overrides so local runs match CI.
+
 ### Code Quality
 
 Lint and format code:

--- a/TESTING.md
+++ b/TESTING.md
@@ -30,8 +30,26 @@ Expected response should include:
 
 ### 1. Start Services
 
+Run the shared test stack helper (recommended):
+
 ```bash
-docker-compose -f docker-compose.test.yml up -d
+./scripts/run_integration_stack.sh
+```
+
+The script will:
+
+- Warn you about any conflicting ports (7474/7687/19530/9091)
+- Start `etcd`, `minio`, `milvus`, and `neo4j` via `docker-compose.test.yml`
+- Wait for each container to report healthy, tailing logs automatically on failure
+- Export the expected `NEO4J_*` and `MILVUS_*` variables
+- Run `poetry run pytest tests/test_milvus_integration.py -v` (pass additional pytest args to override)
+
+Environment overrides (`NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `MILVUS_HOST`, `MILVUS_PORT`) are honored, making it easy to target an already running shared stack instead of launching new containers.
+
+If you need to keep the stack running for manual testing, stop the script with `CTRL+C` *after* the services report healthy and before pytest launches, or start services manually with:
+
+```bash
+docker compose -f docker-compose.test.yml up -d
 ```
 
 This starts:
@@ -40,6 +58,8 @@ This starts:
 - Hermes
 
 ### 2. Wait for Services to be Ready
+
+Skip this step if you used `./scripts/run_integration_stack.sh`; it already polls container health and dumps logs on failure.
 
 ```bash
 # Wait for Milvus

--- a/scripts/run_integration_stack.sh
+++ b/scripts/run_integration_stack.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE=${COMPOSE_CMD:-"docker compose"}
+COMPOSE_FILE=${COMPOSE_FILE:-"docker-compose.test.yml"}
+SERVICES=("etcd" "minio" "milvus" "neo4j")
+HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-180}
+PORTS_TO_CHECK=(
+  "7474:Neo4j HTTP"
+  "7687:Neo4j Bolt"
+  "19530:Milvus gRPC"
+  "9091:Milvus health"
+)
+
+info() {
+  echo "[info] $1"
+}
+
+warn() {
+  echo "[warn] $1"
+}
+
+error() {
+  echo "[error] $1"
+}
+
+check_port_in_use() {
+  local port=$1
+  if command -v ss >/dev/null 2>&1; then
+    if ss -tulpn 2>/dev/null | grep -q ":${port} "; then
+      return 0
+    fi
+  elif command -v lsof >/dev/null 2>&1; then
+    if lsof -i ":${port}" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+container_id() {
+  local service=$1
+  local id=""
+  id=$($COMPOSE -f "$COMPOSE_FILE" ps -q "$service" 2>/dev/null | head -n1 || true)
+  echo "$id"
+}
+
+container_display_name() {
+  local container=$1
+  local name=""
+  name=$(docker inspect -f '{{.Name}}' "$container" 2>/dev/null | sed 's#^/##' || true)
+  echo "${name:-$container}"
+}
+
+wait_for_container() {
+  local service=$1
+  local container_id=$2
+  local display_name=${3:-$2}
+  local deadline=$((SECONDS + HEALTH_TIMEOUT))
+
+  while (( SECONDS < deadline )); do
+    local status=""
+    status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)
+
+    case "$status" in
+      healthy)
+        info "$service ($display_name) is healthy"
+        return 0
+        ;;
+      unhealthy)
+        error "$service ($display_name) reported unhealthy"
+        docker logs "$container_id" --tail=200 || true
+        return 1
+        ;;
+      starting|"" )
+        info "$service ($display_name) still starting (status: ${status:-unknown})"
+        ;;
+      *)
+        warn "$service ($display_name) status: $status"
+        ;;
+    esac
+    sleep 5
+  done
+
+  error "$service ($display_name) did not become healthy within ${HEALTH_TIMEOUT}s"
+  docker logs "$container_id" --tail=200 || true
+  return 1
+}
+
+cleanup() {
+  echo "Stopping integration services..."
+  $COMPOSE -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+echo "Checking for conflicting ports before starting services..."
+for mapping in "${PORTS_TO_CHECK[@]}"; do
+  port=${mapping%%:*}
+  label=${mapping#*:}
+  if check_port_in_use "$port"; then
+    warn "$label (port $port) already in use; existing process may interfere"
+  else
+    info "$label port $port is free"
+  fi
+
+done
+
+echo "Starting Neo4j + Milvus dependencies for Hermes integration tests..."
+if ! $COMPOSE -f "$COMPOSE_FILE" up -d "${SERVICES[@]}"; then
+  error "docker compose failed to start services"
+  $COMPOSE -f "$COMPOSE_FILE" logs --tail=200 || true
+  exit 1
+fi
+
+for service in "${SERVICES[@]}"; do
+  container=$(container_id "$service")
+  if [[ -z "$container" ]]; then
+    error "Unable to determine container ID for service '$service'. Is it running?"
+    $COMPOSE -f "$COMPOSE_FILE" ps "$service" || true
+    exit 1
+  fi
+  display_name=$(container_display_name "$container")
+  if ! wait_for_container "$service" "$container" "$display_name"; then
+    error "Aborting due to unhealthy service: $service"
+    exit 1
+  fi
+
+done
+
+export NEO4J_URI=${NEO4J_URI:-"bolt://localhost:7687"}
+export NEO4J_USER=${NEO4J_USER:-"neo4j"}
+export NEO4J_PASSWORD=${NEO4J_PASSWORD:-"password"}
+export MILVUS_HOST=${MILVUS_HOST:-"localhost"}
+export MILVUS_PORT=${MILVUS_PORT:-"19530"}
+export RUN_HERMES_INTEGRATION=1
+
+default_pytest_args=("tests/test_milvus_integration.py" "-v")
+if [[ $# -gt 0 ]]; then
+  pytest_args=("$@")
+else
+  pytest_args=("${default_pytest_args[@]}")
+fi
+
+info "Running Hermes integration tests via pytest ${pytest_args[*]}"
+poetry run pytest "${pytest_args[@]}"

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,6 +37,18 @@ The `test_milvus_integration.py` file contains tests that verify:
 
 ## Running Integration Tests Locally
 
+### Recommended: Shared Test Stack Helper
+
+Launch the dependencies and run the Milvus/Neo4j integration suite in one step:
+
+```bash
+./scripts/run_integration_stack.sh
+```
+
+The helper checks for port conflicts, waits for each container to become healthy, streams logs on failure, and finally executes `poetry run pytest tests/test_milvus_integration.py -v`. Pass any additional pytest arguments to the script to override the default command.
+
+Environment overrides such as `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `MILVUS_HOST`, and `MILVUS_PORT` are respected, so you can point the tests at an already running stack without restarting containers.
+
 ### Prerequisites
 
 1. Install dependencies:


### PR DESCRIPTION
## Summary
- add `scripts/run_integration_stack.sh` to launch the Neo4j/Milvus stack, stream container logs, and run the Milvus integration suite
- document the helper workflow in README.md, TESTING.md, and tests/README.md including env overrides and the relationship to `docker-compose.test.yml`
- keep the manual instructions for contributors who still want to manage services themselves

## Testing
- `poetry run pytest tests/test_milvus_integration.py -k embedding_response_includes_metadata -v`

Closes #28