### PR TITLE
fix: Build containers for linux/amd64 only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/hermes:${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

Remove linux/arm64 from container build platforms to fix publishing issues. Build amd64-only containers for now.

## Changes

- Update publish workflow to only build for linux/amd64

## Reason

Multi-arch builds are failing because the foundry base image doesn't have arm64 support yet. This allows publishing to proceed with amd64 support.