### PR TITLE
fix: Use correct service names in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Start services
       run: |
-        docker compose -f docker-compose.test.yml up -d etcd minio milvus neo4j
+        docker compose -f docker-compose.test.yml up -d milvus-etcd milvus-minio milvus neo4j
 
     - name: Wait for services
       run: |


### PR DESCRIPTION
## Summary

Fix CI workflow to use correct service names that match docker-compose.test.yml.

## Changes

- Update service names from `etcd` to `milvus-etcd` and `minio` to `milvus-minio` in the CI workflow

## Reason

CI was failing with "no such service: etcd" because the docker-compose file defines the service as `milvus-etcd`, not `etcd`.