### PR TITLE
fix: use CPU-only PyTorch to reduce container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,16 @@ WORKDIR /app/hermes
 COPY src/ ./src/
 COPY pyproject.toml README.md ./
 
+# Install CPU-only PyTorch first to avoid downloading CUDA (saves ~4GB)
+# This must be done before poetry install to ensure we get the CPU version
+RUN pip install --no-cache-dir \
+    torch==2.0.1 \
+    torchaudio==2.0.2 \
+    --index-url https://download.pytorch.org/whl/cpu
+
 # Install Hermes dependencies (including ML packages)
 # Note: foundry base already has Poetry and common dependencies
+# PyTorch is already installed above, so this won't re-download CUDA version
 RUN poetry install --only main --extras ml --no-interaction --no-ansi
 
 # Download spaCy model


### PR DESCRIPTION
## Problem
The Hermes publish-container workflow is failing with "No space left on device" errors on GitHub Actions runners. The issue is caused by Poetry installing the CUDA version of PyTorch by default, which downloads ~4GB of CUDA binaries.

## Solution
Install CPU-only PyTorch explicitly from the PyTorch CPU index **before** running `poetry install`. This ensures Poetry uses the already-installed CPU version instead of downloading the CUDA version.

Changes:
- Add explicit `pip install` for torch and torchaudio from CPU-only index
- This runs before `poetry install --extras ml`
- Saves ~4GB of disk space during build

## Testing
This should allow the publish-container workflow to complete without disk space errors.

Related to #364