### PR TITLE
[hermes] Disable codecov gating temporarily

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+# Codecov configuration
+# Disabling coverage gates temporarily - coverage review planned for later
+# See: https://docs.codecov.com/docs/commit-status
+
+coverage:
+  status:
+    project:
+      default:
+        # Disable project coverage gate
+        informational: true
+    patch:
+      default:
+        # Disable patch coverage gate
+        informational: true
+
+comment:
+  # Still show coverage reports in PR comments for visibility
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

Disable codecov coverage gates temporarily by setting status checks to informational only.

## Context

Coverage gates are blocking CI. A comprehensive test coverage review is planned for later - for now, we want visibility into coverage without it blocking merges.

## Changes

- Add `codecov.yml` with `informational: true` for both project and patch coverage
- Coverage reports will still appear in PR comments for visibility

## Notes

This is a temporary measure. Coverage thresholds will be re-enabled after a test review pass.