### PR TITLE
fix: normalize media_type to lowercase for Sophia compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,11 +34,12 @@ PYTHONUNBUFFERED=1
 # Host address for Sophia cognitive service
 SOPHIA_HOST=localhost
 
-# Port for Sophia service
-SOPHIA_PORT=8001
+# Port for Sophia service (default 8000 for local dev, 8001 for Docker)
+SOPHIA_PORT=8000
 
 # API token for authenticating with Sophia (required for media ingestion)
-# SOPHIA_API_KEY=your-sophia-api-key-here
+# Must match SOPHIA_API_TOKEN set on the Sophia process
+SOPHIA_API_KEY=sophia_dev
 
 # Integration URLs (for documentation purposes)
 # These are examples of how other LOGOS components would be configured

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -495,7 +495,7 @@ class MediaIngestResponse(BaseModel):
 @app.post("/ingest/media", response_model=MediaIngestResponse)
 async def ingest_media(
     file: UploadFile = File(...),
-    media_type: str = "IMAGE",
+    media_type: str = "image",
     question: Optional[str] = None,
 ) -> MediaIngestResponse:
     """Ingest media, process it through Hermes, and forward to Sophia.
@@ -507,13 +507,16 @@ async def ingest_media(
 
     Args:
         file: Media file to ingest (image/video/audio)
-        media_type: Type of media (IMAGE, VIDEO, AUDIO)
+        media_type: Type of media (image, video, audio)
         question: Optional question context for perception
 
     Returns:
         MediaIngestResponse with sample_id and processing results
     """
     import httpx
+
+    # Normalize media_type to lowercase for Sophia compatibility
+    media_type = media_type.lower()
 
     # Get Sophia configuration from environment
     sophia_host = os.getenv("SOPHIA_HOST", "localhost")
@@ -536,7 +539,7 @@ async def ingest_media(
         await file.seek(0)  # Reset for forwarding
 
         # Process based on media type
-        if media_type == "AUDIO":
+        if media_type == "audio":
             # Transcribe audio using Hermes STT
             try:
                 stt_result = await transcribe_audio(file_content)
@@ -552,12 +555,12 @@ async def ingest_media(
             except Exception as e:
                 logger.warning(f"Audio processing failed, continuing with forward: {e}")
 
-        elif media_type == "VIDEO":
+        elif media_type == "video":
             # For video, we could extract audio and transcribe
             # For now, just log and forward
             logger.info(f"Video ingestion: {file.filename}")
 
-        elif media_type == "IMAGE":
+        elif media_type == "image":
             # For images, we could generate description/caption
             # For now, just log and forward
             logger.info(f"Image ingestion: {file.filename}")


### PR DESCRIPTION
## Summary

Fixes media upload proxy to normalize media_type to lowercase for Sophia compatibility.

## Problem

The media upload endpoint was failing with 422 errors because:
- Hermes was sending `media_type: "IMAGE"` (uppercase)
- Sophia expects `media_type: "image"` (lowercase)

## Solution

- Normalize `media_type` to lowercase at the `/ingest/media` endpoint entry
- Update `.env.example` with correct `SOPHIA_PORT` default (8000)
- Document `SOPHIA_API_KEY` requirement for media ingestion

## Changes

- `src/hermes/main.py`: Add `media_type = media_type.lower()` normalization
- `.env.example`: Fix SOPHIA_PORT default from 8001 to 8000

## Testing

- Media upload working end-to-end via Apollo webapp
- Companion PR tests in Apollo capture screenshots

## Related

- Part of #110 media upload via Hermes
- Companion PRs:
  - apollo: `feat/110-media-upload-via-hermes`
  - sophia: `feat/401-cwma-state-emission`
  - logos: `docs/phase2-status-dec2` (#410)