### PR TITLE
chore: use reusable publish workflow from logos

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,13 @@
+# Publish Hermes Container
+# Uses the standardized reusable workflow from logos
+# Part of c-daly/logos#431 - Standardize CI/CD across LOGOS repos
+
 name: Publish Hermes Container
 
 on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to publish (leave empty for latest)'
-        required: false
-        default: ''
 
 permissions:
   contents: read
@@ -16,42 +15,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Extract version from pyproject.toml
-        id: version
-        run: |
-          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Extracted version: $VERSION"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Hermes container
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/hermes:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository_owner }}/hermes:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Image published
-        run: |
-          echo "✅ Hermes container published to ghcr.io/${{ github.repository_owner }}/hermes"
-          echo "Tags: ${{ steps.version.outputs.version }}, latest"
+    uses: c-daly/logos/.github/workflows/reusable-publish.yml@main
+    with:
+      image_name: hermes
+    secrets: inherit


### PR DESCRIPTION
## Summary

Part of c-daly/logos#431 - Standardize CI/CD across LOGOS repos

Updates hermes's `publish.yml` to use the standardized reusable workflow from the logos repository.

## Changes

- Replaced 57-line inline workflow with call to `c-daly/logos/.github/workflows/reusable-publish.yml@main`
- Maintains same triggers (release, workflow_dispatch)

## Benefits

- **Consistency**: Same publishing behavior across all LOGOS repos
- **Maintainability**: Updates to publish logic only need to happen in one place
- **Reduced duplication**: From 57 lines to 21 lines