### PR TITLE
chore: add push-to-main trigger for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,13 @@
 name: Publish Hermes Container
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - 'poetry.lock'
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Part of c-daly/logos#431 - Standardize CI/CD across LOGOS repos

Adds push-to-main trigger to align hermes with sophia/talos publish behavior.

## Changes

- Added `push: branches: [main]` trigger with path filters
- Auto-publishes when `src/**`, `Dockerfile`, `pyproject.toml`, or `poetry.lock` change

## Acceptance Criteria Progress

This addresses: "All repos have identical publish workflow triggers"