### PR TITLE
test: drop two tautological embed tests

### DIFF
--- a/tests/unit/test_clip_provider.py
+++ b/tests/unit/test_clip_provider.py
@@ -136,19 +136,6 @@ class TestLazyLoading:
 
 class TestEmbed:
     @pytest.mark.asyncio
-    async def test_embed_returns_correct_length(self, provider_env):
-        """embed() returns a list of length 768."""
-        provider, _mocks, _mod = provider_env
-        expected = [0.1] * 768
-
-        with patch.object(provider, "_infer_single", return_value=expected):
-            result = await provider.embed(b"fake-image", "image/jpeg")
-
-        assert isinstance(result, list)
-        assert len(result) == 768
-        assert result == expected
-
-    @pytest.mark.asyncio
     async def test_embed_batch_empty(self, provider_env):
         """embed_batch with empty list returns []."""
         provider, _mocks, _mod = provider_env

--- a/tests/unit/test_jepa_provider.py
+++ b/tests/unit/test_jepa_provider.py
@@ -163,19 +163,6 @@ class TestLazyLoading:
 
 class TestEmbed:
     @pytest.mark.asyncio
-    async def test_embed_returns_correct_length(self, provider_env):
-        """embed() returns a list of length 1024."""
-        provider, _mocks, _mod = provider_env
-        expected = [0.1] * 1024
-
-        with patch.object(provider, "_run_inference", return_value=expected):
-            result = await provider.embed(b"fake-image", "image/jpeg")
-
-        assert isinstance(result, list)
-        assert len(result) == 1024
-        assert result == expected
-
-    @pytest.mark.asyncio
     async def test_embed_batch_empty(self, provider_env):
         """embed_batch with empty list returns []."""
         provider, _mocks, _mod = provider_env


### PR DESCRIPTION
## What
Removes the two `TestEmbed::test_embed_returns_correct_length` tests (`test_clip_provider.py` + `test_jepa_provider.py`) that patched the inference fn to return a fixed-length vector then asserted that length — the mock was the assertion.

## Why
Real dimensional output is covered by the integration pipeline tests (`test_clip_integration.py::test_embed_produces_768_dim`, `test_jepa_integration.py::test_embed_produces_1024_dim`). These two added no behavioral protection.

## Verification
- 137 unit tests pass after deletion.
- Independent codex review of the full 5-repo changeset: no sole-guard deletion, no broken collection.

## Not in scope
Test consolidation (e.g. parametrizing `test_name_normalizer`'s 32 cases) and the untested heavy modules (`services.py`, `milvus_client.py`, `env.py`) are deferred to follow-ups.

---
Part of c-daly/logos#529