### PR TITLE
fix(#107): derive embedding dim from provider + recreate stale-dim collections

### DIFF
--- a/src/hermes/milvus_client.py
+++ b/src/hermes/milvus_client.py
@@ -58,6 +58,15 @@ def get_embedding_dimension() -> int:
     )
 
 
+def _embedding_field_dim(collection: Any) -> Optional[int]:
+    """Return the dim of the collection's ``embedding`` FLOAT_VECTOR field, or None."""
+    for field in collection.schema.fields:
+        if field.name == "embedding":
+            params = getattr(field, "params", None) or {}
+            return params.get("dim")
+    return None
+
+
 def get_milvus_host() -> str:
     """Get Milvus host, reading from env on first call."""
     global _milvus_host
@@ -156,12 +165,25 @@ def ensure_collection() -> Optional[Any]:
 
     try:
         collection_name = get_collection_name()
-        # Check if collection already exists
+        expected_dim = get_embedding_dimension()
+        # Reuse an existing collection only if its embedding dimension matches the
+        # provider's. Otherwise drop + recreate so we never write mismatched
+        # vectors (logos#535: a stale 384-dim collection vs a 1536-dim provider).
         if utility.has_collection(collection_name):
-            # Always get a fresh collection reference to avoid stale references
-            # (e.g., if collection was dropped and recreated externally)
-            _milvus_collection = Collection(name=collection_name)
-            return _milvus_collection
+            existing = Collection(name=collection_name)
+            actual_dim = _embedding_field_dim(existing)
+            if actual_dim == expected_dim:
+                _milvus_collection = existing
+                return _milvus_collection
+            logger.warning(
+                "Milvus collection %s has embedding dim %s but the provider needs "
+                "%s — dropping and recreating.",
+                collection_name,
+                actual_dim,
+                expected_dim,
+            )
+            utility.drop_collection(collection_name)
+            _milvus_collection = None
 
         # Create new collection with schema from c-daly/logos#155
         logger.info(f"Creating Milvus collection: {collection_name}")

--- a/src/hermes/milvus_client.py
+++ b/src/hermes/milvus_client.py
@@ -33,25 +33,29 @@ except ImportError:
 _milvus_connected = False
 _milvus_collection: Optional[Any] = None
 
-# Default embedding dimension used when LOGOS_EMBEDDING_DIM is not set.
-EMBEDDING_DIMENSION_DEFAULT = "384"
-
 # Lazy-loaded configuration - deferred until first use to avoid import-time env reads
 _milvus_host: Optional[str] = None
 _milvus_port: Optional[str] = None
 _collection_name: Optional[str] = None
-_embedding_dimension: Optional[int] = None
 
 
 def get_embedding_dimension() -> int:
-    """Get embedding dimension, reading from env on first call."""
-    global _embedding_dimension
-    if _embedding_dimension is None:
-        _embedding_dimension = int(
-            get_env_value("LOGOS_EMBEDDING_DIM", default=EMBEDDING_DIMENSION_DEFAULT)
-            or EMBEDDING_DIMENSION_DEFAULT
-        )
-    return _embedding_dimension
+    """Resolve the embedding dimension from the live provider.
+
+    The running provider's declared dimension is the source of truth; an explicit
+    ``LOGOS_EMBEDDING_DIM`` override is validated against it and fails loud on
+    disagreement (see :func:`logos_config.resolve_embedding_dim`). There is
+    intentionally no hardcoded default — a wrong constant silently drops
+    embeddings (logos#535: a 1536-dim provider writing a 384-dim collection).
+    """
+    from logos_config import get_embedding_dim_override, resolve_embedding_dim
+
+    from hermes import embedding_provider
+
+    declared = embedding_provider.get_embedding_provider().dimension
+    return resolve_embedding_dim(
+        measured_dim=declared, override=get_embedding_dim_override()
+    )
 
 
 def get_milvus_host() -> str:

--- a/tests/test_milvus_dim_recreate.py
+++ b/tests/test_milvus_dim_recreate.py
@@ -1,0 +1,84 @@
+"""ensure_collection must recreate a collection whose dim no longer matches the
+provider, instead of silently reusing it (logos#535).
+
+Integration test — needs a reachable Milvus (dev stack on localhost:19530).
+"""
+
+from __future__ import annotations
+
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+import hermes.embedding_provider as embedding_provider
+import hermes.milvus_client as mc
+
+
+def _milvus_up(host: str = "localhost", port: int = 19530) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(not _milvus_up(), reason="dev Milvus not reachable on :19530")
+def test_ensure_collection_recreates_on_dim_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pymilvus import (
+        Collection,
+        CollectionSchema,
+        DataType,
+        FieldSchema,
+        utility,
+    )
+
+    name = "test_535_dim_recreate"
+    monkeypatch.setenv("MILVUS_HOST", "localhost")
+    monkeypatch.setenv("MILVUS_PORT", "19530")
+    monkeypatch.setenv("MILVUS_COLLECTION_NAME", name)
+    monkeypatch.delenv("LOGOS_EMBEDDING_DIM", raising=False)
+
+    # reset module connection/cache globals
+    mc._milvus_connected = False
+    mc._milvus_collection = None
+    mc._collection_name = None
+    mc._milvus_host = None
+    mc._milvus_port = None
+
+    assert mc.connect_milvus(), "could not connect to dev Milvus"
+
+    # Seed a STALE 384-dim collection (the pre-fix state).
+    if utility.has_collection(name):
+        utility.drop_collection(name)
+    Collection(
+        name=name,
+        schema=CollectionSchema(
+            [
+                FieldSchema("embedding_id", DataType.VARCHAR, is_primary=True, max_length=64),
+                FieldSchema("embedding", DataType.FLOAT_VECTOR, dim=384),
+                FieldSchema("model", DataType.VARCHAR, max_length=256),
+                FieldSchema("text", DataType.VARCHAR, max_length=65535),
+                FieldSchema("timestamp", DataType.INT64),
+            ]
+        ),
+    )
+
+    try:
+        # Provider now declares 1536 — ensure_collection must recreate, not reuse.
+        monkeypatch.setattr(
+            embedding_provider,
+            "get_embedding_provider",
+            lambda: SimpleNamespace(dimension=1536, model_name="fake-1536"),
+        )
+        mc._milvus_collection = None
+
+        collection = mc.ensure_collection()
+
+        assert collection is not None
+        assert mc._embedding_field_dim(collection) == 1536
+    finally:
+        if utility.has_collection(name):
+            utility.drop_collection(name)

--- a/tests/test_milvus_embedding_dim.py
+++ b/tests/test_milvus_embedding_dim.py
@@ -1,0 +1,44 @@
+"""The embedding collection dimension must come from the live provider.
+
+Regression for logos#535: Hermes auto-selects the OpenAI provider (1536-dim)
+when a key is present, but the collection was hardcoded to 384 -> every insert
+failed with a num_rows mismatch and embeddings were silently dropped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import hermes.embedding_provider as embedding_provider
+from hermes import milvus_client
+
+
+class TestEmbeddingDimensionFromProvider:
+    def test_dimension_comes_from_provider_not_hardcoded_384(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 1536-dim provider yields collection dim 1536, not the old 384."""
+        monkeypatch.delenv("LOGOS_EMBEDDING_DIM", raising=False)
+        monkeypatch.setattr(
+            embedding_provider,
+            "get_embedding_provider",
+            lambda: SimpleNamespace(dimension=1536, model_name="fake-1536"),
+        )
+        assert milvus_client.get_embedding_dimension() == 1536
+
+    def test_override_disagreeing_with_provider_fails_loud(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """LOGOS_EMBEDDING_DIM that the provider can't deliver raises, never silent."""
+        from logos_config import EmbeddingDimMismatch
+
+        monkeypatch.setenv("LOGOS_EMBEDDING_DIM", "512")
+        monkeypatch.setattr(
+            embedding_provider,
+            "get_embedding_provider",
+            lambda: SimpleNamespace(dimension=384, model_name="fake-384"),
+        )
+        with pytest.raises(EmbeddingDimMismatch):
+            milvus_client.get_embedding_dimension()


### PR DESCRIPTION
Closes #107 (sub-ticket of the embedding-dim coherence epic c-daly/logos#535).

- `get_embedding_dimension()` derives from the live provider + validates any `LOGOS_EMBEDDING_DIM` override (`logos_config.resolve_embedding_dim`); removes `EMBEDDING_DIMENSION_DEFAULT='384'`.
- `ensure_collection()` recreates a stale-dim collection instead of reusing it.

TDD'd (unit + live-Milvus integration); demonstrated live on the dev stack (recreated hermes_embeddings 384→1536, embeddings persist). **Depends on** the logos_config foundry change (c-daly/logos#541, PR c-daly/logos#540).