### PR TITLE
test(#111): live regression test for embedding persistence (row count grows by N)

### DIFF
--- a/tests/integration/test_milvus_persist_rowcount.py
+++ b/tests/integration/test_milvus_persist_rowcount.py
@@ -53,12 +53,16 @@ async def test_persist_embedding_grows_row_count_by_n(
         lambda: SimpleNamespace(dimension=_DIM, model_name="fake-persist"),
     )
 
-    # Reset module connection/cache globals so the patched env/provider take effect.
-    mc._milvus_connected = False
-    mc._milvus_collection = None
-    mc._collection_name = None
-    mc._milvus_host = None
-    mc._milvus_port = None
+    # Reset module connection/cache globals so the patched env/provider take
+    # effect. Use monkeypatch.setattr (not direct assignment) so all five are
+    # automatically restored to their pre-test values at teardown — this leaves
+    # no leaked module state (incl. the _milvus_collection cache handle) for
+    # other tests, regardless of what this test mutates mid-run.
+    monkeypatch.setattr(mc, "_milvus_connected", False)
+    monkeypatch.setattr(mc, "_milvus_collection", None)
+    monkeypatch.setattr(mc, "_collection_name", None)
+    monkeypatch.setattr(mc, "_milvus_host", None)
+    monkeypatch.setattr(mc, "_milvus_port", None)
 
     assert mc.connect_milvus(), "could not connect to dev Milvus"
 

--- a/tests/integration/test_milvus_persist_rowcount.py
+++ b/tests/integration/test_milvus_persist_rowcount.py
@@ -1,0 +1,111 @@
+"""persist_embedding must actually write rows: persisting N embeddings grows the
+collection by exactly N (logos#535 hermes-side acceptance, hermes#111).
+
+This guards the keystone regression — "extracted 18 entities, persisted 0
+embeddings" — where a stale-dim / wrongly-shaped insert made every
+``persist_embedding`` silently fail. A unit test with a mocked collection cannot
+catch that; the row count has to be read back from a real Milvus.
+
+Integration test — needs a reachable Milvus (dev stack on localhost:19530).
+"""
+
+from __future__ import annotations
+
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+import hermes.embedding_provider as embedding_provider
+import hermes.milvus_client as mc
+
+# Small, model-free dimension: this test is about row persistence, not embedding
+# quality, so we patch the provider rather than load sentence-transformers.
+_DIM = 8
+
+
+def _milvus_up(host: str = "localhost", port: int = 19530) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _milvus_up(), reason="dev Milvus not reachable on :19530")
+async def test_persist_embedding_grows_row_count_by_n(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pymilvus import utility
+
+    name = "test_111_persist_rowcount"
+    monkeypatch.setenv("MILVUS_HOST", "localhost")
+    monkeypatch.setenv("MILVUS_PORT", "19530")
+    monkeypatch.setenv("MILVUS_COLLECTION_NAME", name)
+    monkeypatch.delenv("LOGOS_EMBEDDING_DIM", raising=False)
+
+    # Provider dimension is the source of truth for the collection schema; pin it
+    # to a fake so the test neither loads a model nor depends on the live dim.
+    monkeypatch.setattr(
+        embedding_provider,
+        "get_embedding_provider",
+        lambda: SimpleNamespace(dimension=_DIM, model_name="fake-persist"),
+    )
+
+    # Reset module connection/cache globals so the patched env/provider take effect.
+    mc._milvus_connected = False
+    mc._milvus_collection = None
+    mc._collection_name = None
+    mc._milvus_host = None
+    mc._milvus_port = None
+
+    assert mc.connect_milvus(), "could not connect to dev Milvus"
+
+    # Start from a clean collection so the row delta is unambiguous.
+    if utility.has_collection(name):
+        utility.drop_collection(name)
+    mc._milvus_collection = None
+
+    try:
+        collection = mc.ensure_collection()
+        assert collection is not None
+
+        # Insert shape must match the schema dim (the num_rows-mismatch guard).
+        schema_dim = mc._embedding_field_dim(collection)
+        assert schema_dim == _DIM, f"collection dim {schema_dim} != provider {_DIM}"
+
+        collection.flush()
+        baseline = collection.num_entities
+        assert baseline == 0, (
+            f"fresh collection should start empty, got {baseline} "
+            "(drop_collection may have failed or stale data exists)"
+        )
+
+        n = 5
+        for i in range(n):
+            ok = await mc.persist_embedding(
+                embedding_id=f"emb-{i}",
+                embedding=[0.1] * schema_dim,
+                model="fake-persist",
+                text=f"persist regression row {i}",
+            )
+            assert ok is True, f"persist_embedding returned False for row {i}"
+
+        # num_entities only reflects sealed segments, so flush before counting.
+        collection.flush()
+        assert collection.num_entities == baseline + n
+
+        # Read a row back to confirm the persisted vector carries the schema dim
+        # (the "insert shape matches the collection schema dim" half of #111 —
+        # guards against a silently truncated / reshaped insert, not just a
+        # missing one).
+        collection.load()
+        rows = collection.query(
+            expr='embedding_id == "emb-0"', output_fields=["embedding"]
+        )
+        assert len(rows) == 1
+        assert len(rows[0]["embedding"]) == schema_dim
+    finally:
+        if utility.has_collection(name):
+            utility.drop_collection(name)


### PR DESCRIPTION
Closes #111. Part of the embedding-dimension epic c-daly/logos#535 (hermes-side acceptance).

## Why
#535's hermes-side acceptance calls for a **live-Milvus regression test** proving that persisting N embeddings grows the collection by N rows — there was none. The keystone symptom ("extracted 18 entities, persisted 0 embeddings", a `num_rows`/dim mismatch) is fixed by the v0.7.2 embedding-dim work, but nothing guarded `persist_embedding` against a regression. A unit test with a mocked collection can't catch a silent-write failure; the row count has to be read back from a real Milvus.

## What
Adds `tests/integration/test_milvus_persist_rowcount.py`:
- Persists N=5 embeddings via `hermes.milvus_client.persist_embedding` against a live Milvus, flushes, and asserts `num_entities` grew by **exactly N**.
- Reads a row back (`collection.query`) and asserts the persisted vector carries the schema dim — the *"insert shape matches the collection schema dim"* half of #111, guarding against a silently truncated/reshaped insert (not just a missing one).
- Skips via a socket check when Milvus is unreachable (mirrors the sibling `test_milvus_dim_recreate.py`), and patches the embedding provider to a fixed dim so it stays model-free (no sentence-transformers load).
- Marked `@pytest.mark.integration`.

## Verification
- ✅ Passes live against dev Milvus on `:19530`.
- ✅ **Red-green**: disabling `collection.insert` in `persist_embedding` makes it fail at `assert num_entities == baseline + n` (`assert 0 == 5`); restoring fixes it.
- ✅ Passes alongside `test_milvus_dim_recreate.py` in **both orders** (no cross-test state/connection collision).
- ✅ ruff / black / mypy clean.

## Scope notes
Test-only; no production code changed. Adversarial review flagged a couple of pre-existing/optional items left out of this PR to keep it focused: stale `mc._embedding_dimension = None` no-ops in `tests/conftest.py`, and `_milvus_up` duplication between the two integration tests (DRY into a shared conftest). Happy to follow up on those separately.