### PR TITLE
feat(#505): /name-cluster endpoint for emergent type naming + distinct-name prompt

### DIFF
--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1419,9 +1419,12 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
 
     system_msg = (
         "You name the single category that binds a cluster of entities together. "
-        "Find the common thread even if it must be broad; never refuse. Prefer an "
-        "existing category if one genuinely fits, otherwise propose a new lowercase "
-        'noun. Return ONLY a JSON object: '
+        "Find the common thread; never refuse. Reuse one of the existing categories "
+        "ONLY if this cluster is the same kind of thing as that category. If it "
+        "differs from every existing category, coin a NEW, specific lowercase noun "
+        "that distinguishes it from them -- do NOT reuse a broad existing label for "
+        "a distinct group (e.g. do not name three different groups all 'ecosystem'; "
+        "use 'forest ecosystem', 'coral reef', etc.). Return ONLY a JSON object: "
         '{"label": "<noun>", "description": "<short>", "confidence": <0.0-1.0>}.'
     )
     user_msg = (

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1378,6 +1378,77 @@ async def name_type(request: NameTypeRequest) -> NameTypeResponse:
     return NameTypeResponse(type_name=data["type_name"])
 
 
+class NameClusterMember(BaseModel):
+    name: str
+    type: Optional[str] = None
+    hermes_type_hint: Optional[str] = None
+    neighbors: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class NameClusterRequest(BaseModel):
+    members: List[NameClusterMember]
+    candidates: List[str] = Field(default_factory=list)
+
+
+class NameClusterResponse(BaseModel):
+    label: str
+    description: str = ""
+    confidence: float = 0.5
+
+
+@app.post("/name-cluster", response_model=NameClusterResponse)
+async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
+    """Name the single category that binds a cluster of nodes (Sophia emergence #505).
+
+    Sophia knows *that* the members belong together; Hermes says *what* they are.
+    """
+    member_lines = []
+    for mem in request.members:
+        line = f"- {mem.name}"
+        if mem.hermes_type_hint:
+            line += f" (hint: {mem.hermes_type_hint})"
+        if mem.neighbors:
+            rels = ", ".join(
+                f"{n.get('relation', '?')}->{n.get('neighbor_name', '?')}"
+                for n in mem.neighbors
+            )
+            line += f"; relations: {rels}"
+        member_lines.append(line)
+    members_block = "\n".join(member_lines)
+    candidates = ", ".join(request.candidates) if request.candidates else "(none)"
+
+    system_msg = (
+        "You name the single category that binds a cluster of entities together. "
+        "Find the common thread even if it must be broad; never refuse. Prefer an "
+        "existing category if one genuinely fits, otherwise propose a new lowercase "
+        'noun. Return ONLY a JSON object: '
+        '{"label": "<noun>", "description": "<short>", "confidence": <0.0-1.0>}.'
+    )
+    user_msg = (
+        f"Existing categories: {candidates}\n\n"
+        "These entities were grouped together (semantically and structurally "
+        f"similar):\n{members_block}\n\nWhat single category binds them?"
+    )
+
+    result = await generate_completion(
+        messages=[
+            {"role": "system", "content": system_msg},
+            {"role": "user", "content": user_msg},
+        ],
+        temperature=0.0,
+        max_tokens=128,
+    )
+    choices = result.get("choices", [])
+    if not choices:
+        raise HTTPException(status_code=502, detail="LLM returned no choices")
+    data = _extract_json(choices[0]["message"]["content"])
+    return NameClusterResponse(
+        label=str(data["label"]).strip().lower(),
+        description=str(data.get("description", "")),
+        confidence=float(data.get("confidence", 0.5)),
+    )
+
+
 class NameRelationshipRequest(BaseModel):
     source_name: str = Field(..., description="Source node name")
     target_name: str = Field(..., description="Target node name")

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1386,7 +1386,9 @@ class NameClusterMember(BaseModel):
 
 
 class NameClusterRequest(BaseModel):
-    members: List[NameClusterMember]
+    members: List[NameClusterMember] = Field(
+        ..., min_length=1, description="Cluster members to name (must be non-empty)"
+    )
     candidates: List[str] = Field(default_factory=list)
 
 
@@ -1444,11 +1446,29 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
     choices = result.get("choices", [])
     if not choices:
         raise HTTPException(status_code=502, detail="LLM returned no choices")
-    data = _extract_json(choices[0]["message"]["content"])
+    # The LLM response shape is untrusted: a missing key, non-dict JSON, or
+    # unparseable content must surface as a 502 (bad upstream response), not an
+    # unhandled 500. Confidence is clamped to the documented [0.0, 1.0] range.
+    try:
+        data = _extract_json(choices[0]["message"]["content"])
+        if not isinstance(data, dict):
+            raise ValueError("LLM response is not a JSON object")
+        label = data.get("label")
+        if not label:
+            raise KeyError("label")
+        try:
+            confidence = float(data.get("confidence", 0.5))
+        except (TypeError, ValueError):
+            confidence = 0.5
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to parse LLM cluster-name response: {e}",
+        )
     return NameClusterResponse(
-        label=str(data["label"]).strip().lower(),
+        label=str(label).strip().lower(),
         description=str(data.get("description", "")),
-        confidence=float(data.get("confidence", 0.5)),
+        confidence=min(1.0, max(0.0, confidence)),
     )
 
 

--- a/tests/test_name_cluster.py
+++ b/tests/test_name_cluster.py
@@ -47,3 +47,43 @@ def test_name_cluster_names_the_bind(monkeypatch):
     body = resp.json()
     assert body["label"] == "concept"  # normalized to lowercase
     assert 0.0 <= body["confidence"] <= 1.0
+
+
+def test_name_cluster_rejects_empty_members():
+    """An empty cluster is a 422 (validation), not a fabricated label (greptile P1)."""
+    client = TestClient(m.app)
+    resp = client.post(
+        "/name-cluster",
+        json={"members": [], "candidates": ["object", "concept"]},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_name_cluster_clamps_out_of_range_confidence(monkeypatch):
+    """A model confidence outside [0,1] is clamped, not passed through (greptile P2)."""
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=128):
+        return {
+            "choices": [
+                {"message": {"content": '{"label": "thing", "confidence": 1.7}'}}
+            ]
+        }
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+    client = TestClient(m.app)
+    resp = client.post("/name-cluster", json={"members": [{"name": "x"}]})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["confidence"] == 1.0
+
+
+def test_name_cluster_malformed_llm_response_is_502(monkeypatch):
+    """Unparseable / label-less LLM output surfaces as 502, not an unhandled 500
+    (gemini high / greptile P2)."""
+
+    async def no_label(messages, temperature=0.0, max_tokens=128):
+        return {"choices": [{"message": {"content": '{"name": "oops"}'}}]}
+
+    monkeypatch.setattr(m, "generate_completion", no_label)
+    client = TestClient(m.app)
+    resp = client.post("/name-cluster", json={"members": [{"name": "x"}]})
+    assert resp.status_code == 502, resp.text

--- a/tests/test_name_cluster.py
+++ b/tests/test_name_cluster.py
@@ -1,0 +1,49 @@
+"""Tests for the /name-cluster endpoint (Sophia emergence #505)."""
+
+from __future__ import annotations
+
+import hermes.main as m
+from fastapi.testclient import TestClient
+
+
+def test_name_cluster_names_the_bind(monkeypatch):
+    async def fake_completion(messages, temperature=0.0, max_tokens=128):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"label": "Concept", '
+                        '"description": "abstract ideas", "confidence": 0.82}'
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+
+    client = TestClient(m.app)
+    resp = client.post(
+        "/name-cluster",
+        json={
+            "members": [
+                {
+                    "name": "derivative",
+                    "type": "entity",
+                    "hermes_type_hint": "concept",
+                    "neighbors": [
+                        {
+                            "relation": "DEFINED_AS",
+                            "neighbor_name": "limit",
+                            "neighbor_type": "entity",
+                        }
+                    ],
+                },
+                {"name": "integral", "type": "entity", "hermes_type_hint": "concept"},
+            ],
+            "candidates": ["object", "location", "concept"],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["label"] == "concept"  # normalized to lowercase
+    assert 0.0 <= body["confidence"] <= 1.0


### PR DESCRIPTION
## Summary
Hermes side of Sophia's #505 emergence. Two commits:

1. `542d233` — add the `POST /name-cluster` endpoint: given a cluster of grouped entities (+ the existing category names Sophia sends as `candidates`), an LLM names the single category that binds them, returning `{label, description, confidence}`.

2. `32e5703` — make the naming prompt coin **distinct** names for **distinct** clusters.

## Why the prompt change
The original system prompt told the model to *"prefer an existing category... even if it must be broad."* In practice that stamped the same coarse label on semantically distinct clusters — e.g. three clusters with pairwise cosine ~0.3–0.6 all came back `laboratory apparatus` (earlier: `ecosystem` ×3). Those then minted as same-named type-defs in the graph that read as duplicates.

New behavior: reuse an existing category **only** when the cluster is the same kind of thing; otherwise coin a new, specific lowercase noun that distinguishes it. Leans on the `candidates` list Sophia already passes.

## Verified
Live against Sophia on the paired branch (`feat/505-emergence-simple-lineage-hierarchy`): re-running the corpus, same-name dupes dropped from many (`ecosystem` ×3, `organism` ×2) to a single residual (`laboratory apparatus` ×3, genuinely distinct clusters), with Hermes now producing specific labels — `measurement apparatus`, `light measurement component`, `analytical component`, `chemical solution`, `marine entity`, `adaptive organism`, etc. `ruff` clean, `main.py` parses.

Pairs with sophia#159.