### PR TITLE
feat(#504): /name-cluster returns removed[] outliers

### DIFF
--- a/src/hermes/combined_extractor.py
+++ b/src/hermes/combined_extractor.py
@@ -105,9 +105,9 @@ class OpenAICombinedExtractor:
             "normalized form, ISO-8601 where possible ('1943'->'1943', "
             "'March 1898'->'1898-03', 'the 1950s'->'195X'); \"unit\" is null\n"
             "- Quantitative entities (type 'data': measurements/quantities): set "
-            "\"value\" to the numeric magnitude and \"unit\" to the unit "
+            '"value" to the numeric magnitude and "unit" to the unit '
             "('10 km'->10/'km'; '5 mg'->5/'mg'); plain counts: \"unit\" is null\n"
-            "- All other entities: \"value\" and \"unit\" are null\n"
+            '- All other entities: "value" and "unit" are null\n'
             "- Relation source_name and target_name must exactly match an "
             "extracted entity name\n"
             "- Use specific UPPER_SNAKE_CASE relation labels (e.g. LOCATED_IN, "

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1419,7 +1419,10 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
             {"role": "user", "content": user_msg},
         ],
         temperature=0.0,
-        max_tokens=128,
+        # Label + description are short, but the response now also carries a
+        # `removed` array of member names; 128 tokens could truncate it mid-array
+        # into unparseable JSON (a 502). Give the outlier list room to complete.
+        max_tokens=512,
     )
     choices = result.get("choices", [])
     if not choices:
@@ -1445,7 +1448,12 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
         )
     # Hermes flags outliers by name; map them back to the caller's member ids so
     # Sophia can exclude them from the minted type without re-matching names.
+    # `removed` is optional and secondary: a malformed value (non-list, null, or
+    # a truncated array) must not 500 or discard an otherwise-valid name -- degrade
+    # to "no outliers", mirroring how confidence is defaulted above.
     removed_raw = data.get("removed", [])
+    if not isinstance(removed_raw, list):
+        removed_raw = []
     removed_names = {
         str(n).strip().lower() for n in removed_raw if isinstance(n, (str, int, float))
     }

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1345,6 +1345,7 @@ async def name_type(request: NameTypeRequest) -> NameTypeResponse:
 
 class NameClusterMember(BaseModel):
     name: str
+    id: Optional[str] = None
     type: Optional[str] = None
     hermes_type_hint: Optional[str] = None
     neighbors: List[Dict[str, Any]] = Field(default_factory=list)
@@ -1361,6 +1362,10 @@ class NameClusterResponse(BaseModel):
     label: str
     description: str = ""
     confidence: float = 0.5
+    removed: List[str] = Field(
+        default_factory=list,
+        description="Member ids that do not fit the named category (outliers).",
+    )
 
 
 @app.post("/name-cluster", response_model=NameClusterResponse)
@@ -1391,8 +1396,16 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
         "differs from every existing category, coin a NEW, specific lowercase noun "
         "that distinguishes it from them -- do NOT reuse a broad existing label for "
         "a distinct group (e.g. do not name three different groups all 'ecosystem'; "
-        "use 'forest ecosystem', 'coral reef', etc.). Return ONLY a JSON object: "
-        '{"label": "<noun>", "description": "<short>", "confidence": <0.0-1.0>}.'
+        "use 'forest ecosystem', 'coral reef', etc.). "
+        "Most members share one obvious category, but a few may NOT belong -- a "
+        "PART of another member, or a different kind of thing -- and would force a "
+        "looser, more general name. List any such members by their EXACT name in "
+        "'removed', then name the category of the REMAINING coherent majority. "
+        "Leave 'removed' empty when every member fits one specific category "
+        "(same-kind nesting, e.g. a component within a component, is NOT a removal). "
+        "Return ONLY a JSON object: "
+        '{"label": "<noun>", "description": "<short>", "confidence": <0.0-1.0>, '
+        '"removed": ["<member name>", ...]}.'
     )
     user_msg = (
         f"Existing categories: {candidates}\n\n"
@@ -1430,10 +1443,22 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
             status_code=502,
             detail=f"Failed to parse LLM cluster-name response: {e}",
         )
+    # Hermes flags outliers by name; map them back to the caller's member ids so
+    # Sophia can exclude them from the minted type without re-matching names.
+    removed_raw = data.get("removed", [])
+    removed_names = {
+        str(n).strip().lower() for n in removed_raw if isinstance(n, (str, int, float))
+    }
+    removed_ids = [
+        mem.id
+        for mem in request.members
+        if mem.id and mem.name.strip().lower() in removed_names
+    ]
     return NameClusterResponse(
         label=str(label).strip().lower(),
         description=str(data.get("description", "")),
         confidence=min(1.0, max(0.0, confidence)),
+        removed=removed_ids,
     )
 
 

--- a/tests/test_name_cluster.py
+++ b/tests/test_name_cluster.py
@@ -128,7 +128,7 @@ def test_name_cluster_maps_removed_names_to_ids(monkeypatch):
 def test_name_cluster_removed_defaults_empty(monkeypatch):
     """A response with no 'removed' key yields an empty list, not an error (#504)."""
 
-    async def fake_completion(messages, temperature=0.0, max_tokens=128):
+    async def fake_completion(messages, temperature=0.0, max_tokens=512):
         return {
             "choices": [
                 {"message": {"content": '{"label": "tree", "confidence": 0.9}'}}
@@ -143,3 +143,32 @@ def test_name_cluster_removed_defaults_empty(monkeypatch):
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["removed"] == []
+
+
+def test_name_cluster_malformed_removed_degrades_not_500(monkeypatch):
+    """A non-list 'removed' (here an int) must not crash the mapping (greptile):
+    the label is still valid, so degrade to no outliers rather than a 500."""
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=512):
+        # `removed` is a bare int -> not iterable. Pre-fix this raised a 500.
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"label": "tree", "confidence": 0.9, '
+                        '"removed": 7}'
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+    client = TestClient(m.app)
+    resp = client.post(
+        "/name-cluster",
+        json={"members": [{"name": "oak", "id": "n1"}]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["label"] == "tree"
+    assert body["removed"] == []

--- a/tests/test_name_cluster.py
+++ b/tests/test_name_cluster.py
@@ -87,3 +87,59 @@ def test_name_cluster_malformed_llm_response_is_502(monkeypatch):
     client = TestClient(m.app)
     resp = client.post("/name-cluster", json={"members": [{"name": "x"}]})
     assert resp.status_code == 502, resp.text
+
+
+def test_name_cluster_maps_removed_names_to_ids(monkeypatch):
+    """Outliers Hermes flags by name come back as the caller's member ids (#504)."""
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=128):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"label": "tree", "confidence": 0.9, '
+                        '"removed": ["Tusk", "amber sap"]}'
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+    client = TestClient(m.app)
+    resp = client.post(
+        "/name-cluster",
+        json={
+            "members": [
+                {"name": "oak", "id": "n1"},
+                {"name": "pine", "id": "n2"},
+                {"name": "tusk", "id": "n3"},  # case-insensitive match to "Tusk"
+                {"name": "amber sap", "id": "n4"},
+            ],
+            "candidates": [],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["label"] == "tree"
+    # Names map back to ids, case-insensitively; coherent majority is untouched.
+    assert set(body["removed"]) == {"n3", "n4"}
+
+
+def test_name_cluster_removed_defaults_empty(monkeypatch):
+    """A response with no 'removed' key yields an empty list, not an error (#504)."""
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=128):
+        return {
+            "choices": [
+                {"message": {"content": '{"label": "tree", "confidence": 0.9}'}}
+            ]
+        }
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+    client = TestClient(m.app)
+    resp = client.post(
+        "/name-cluster",
+        json={"members": [{"name": "oak", "id": "n1"}]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["removed"] == []


### PR DESCRIPTION
## What

`/name-cluster` now returns a `removed[]` list: the cluster members the LLM
judges **don't** belong to the named category — a PART of another member, or a
different kind of thing — that would otherwise force a looser, more general name.

Sophia knows *that* a cluster's members were grouped together; Hermes already
said *what* binds them. This adds *which ones don't*, so Sophia can mint the
coherent majority and leave the outliers behind.

## Why

This is the **naming-time** half of the membership-coherence fix for
`c-daly/logos#504`. The structural PART_OF evictor (Sophia side) is a coarse,
per-edge interim pass; it cannot tell a self-similar part-type (a component
*within* a component) from a true meronymic outlier, and would wrongly evict the
former. Hermes's semantic judgment makes that distinction correctly: same-kind
nesting is explicitly **not** a removal.

## Changes

- `NameClusterMember` gains optional `id` — a caller-stable handle so Hermes can
  flag a member back by id without the caller re-matching names.
- `NameClusterResponse` gains `removed: List[str]` (member ids).
- Prompt: name the coherent majority, list outliers by exact name; leave
  `removed` empty when every member fits one specific category.
- Handler maps the LLM's by-name flags → caller member ids (case-insensitive).

## Tests

- `removed` names map back to the right ids (case-insensitive)
- absent `removed` key defaults to `[]` (no error)
- existing name-cluster tests unchanged (6 pass)

## Paired with

`c-daly/sophia` PR — the consumer side (sends `id`, excludes `removed` members
from minting). The contract degrades gracefully in both directions: old Hermes →
Sophia excludes nothing; old Sophia (no `id`) → nothing to map back. The feature
engages only once both are deployed.

Refs c-daly/logos#504
