### PR TITLE
feat(name-cluster): return an optional graft parent for new labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Production-ready Dockerfile for Hermes API server
 # Optimized for FastAPI/uvicorn with stateless design
-FROM ghcr.io/c-daly/logos-foundry:0.7.2
+FROM ghcr.io/c-daly/logos-foundry:0.7.3
 
 # Add metadata labels following OCI standards
 LABEL org.opencontainers.image.title="Hermes API" \

--- a/poetry.lock
+++ b/poetry.lock
@@ -1160,7 +1160,7 @@ files = [
 
 [[package]]
 name = "logos-foundry"
-version = "0.7.2"
+version = "0.7.3"
 description = "LOGOS Foundry - Canonical source of truth for Project LOGOS specifications, ontology, and infrastructure"
 optional = false
 python-versions = "^3.12"
@@ -1184,8 +1184,8 @@ uvicorn = {version = "^0.32.0", extras = ["standard"]}
 [package.source]
 type = "git"
 url = "https://github.com/c-daly/logos.git"
-reference = "v0.7.2"
-resolved_reference = "7c50b3415eaf885637f2675081e417d745c35b3d"
+reference = "v0.7.3"
+resolved_reference = "df52348fc1c393c3401ecbdd98198aaaff560147"
 
 [[package]]
 name = "marisa-trie"
@@ -5035,4 +5035,4 @@ otel = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-instr
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "a5ded7c266b59f321e74e4be631c992e76aada2b2124b8551985ffe8e5790b5e"
+content-hash = "bb0eafa30cdaee65050fea74e7e52a62242f7c04c42818497f91e28e7281557d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "pymilvus>=2.3.0",
   "pandas>=2.0.0",
   # logos-foundry provides logos_config and logos_test_utils
-  "logos-foundry @ git+https://github.com/c-daly/logos.git@v0.7.2 ; python_version >= '3.12' and python_version < '4.0'",
+  "logos-foundry @ git+https://github.com/c-daly/logos.git@v0.7.3 ; python_version >= '3.12' and python_version < '4.0'",
   "numpy>=1.24.0,<2.4",
   "redis>=5.0.0",
   "nltk>=3.8.0",
@@ -79,7 +79,7 @@ packages = [{ include = "hermes", from = "src" }]
 
 [tool.poetry.dependencies]
 # logos-foundry must be declared here for Poetry to resolve git deps
-logos-foundry = { git = "https://github.com/c-daly/logos.git", tag = "v0.7.2" }
+logos-foundry = { git = "https://github.com/c-daly/logos.git", tag = "v0.7.3" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1484,9 +1484,14 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
     graft_parent: Optional[str] = None
     if isinstance(parent_raw, str):
         cand_by_lower = {c.strip().lower(): c.strip() for c in request.candidates}
-        matched = cand_by_lower.get(parent_raw.strip().lower())
-        if matched and matched.lower() != label_norm:
-            graft_parent = matched
+        # `parent` applies only to a NEWLY coined label. If the label is itself an
+        # existing candidate (reuse), the contract requires `parent=None` --
+        # otherwise Sophia would try to graft an existing type under a new parent
+        # (review: "null on reuse").
+        if label_norm not in cand_by_lower:
+            matched = cand_by_lower.get(parent_raw.strip().lower())
+            if matched and matched.lower() != label_norm:
+                graft_parent = matched
     return NameClusterResponse(
         label=label_norm,
         description=str(data.get("description", "")),

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1366,6 +1366,14 @@ class NameClusterResponse(BaseModel):
         default_factory=list,
         description="Member ids that do not fit the named category (outliers).",
     )
+    parent: Optional[str] = Field(
+        default=None,
+        description=(
+            "When `label` is a newly coined type (not one of the supplied "
+            "candidates), the existing candidate to graft it under; None when "
+            "reusing a candidate or no listed category is a sensible parent."
+        ),
+    )
 
 
 @app.post("/name-cluster", response_model=NameClusterResponse)
@@ -1397,6 +1405,10 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
         "that distinguishes it from them -- do NOT reuse a broad existing label for "
         "a distinct group (e.g. do not name three different groups all 'ecosystem'; "
         "use 'forest ecosystem', 'coral reef', etc.). "
+        "When you coin a NEW category, also set 'parent' to the single existing "
+        "category above that best generalizes it (its closest broader supertype) "
+        "so it can be grafted into the hierarchy; use null for 'parent' when you "
+        "reuse an existing category or none is a sensible parent. "
         "Most members share one obvious category, but a few may NOT belong -- a "
         "PART of another member, or a different kind of thing -- and would force a "
         "looser, more general name. List any such members by their EXACT name in "
@@ -1405,7 +1417,7 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
         "(same-kind nesting, e.g. a component within a component, is NOT a removal). "
         "Return ONLY a JSON object: "
         '{"label": "<noun>", "description": "<short>", "confidence": <0.0-1.0>, '
-        '"removed": ["<member name>", ...]}.'
+        '"removed": ["<member name>", ...], "parent": "<existing category or null>"}.'
     )
     user_msg = (
         f"Existing categories: {candidates}\n\n"
@@ -1462,11 +1474,25 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
         for mem in request.members
         if mem.id and mem.name.strip().lower() in removed_names
     ]
+    # Graft parent: when Hermes coins a NEW label it may name an existing
+    # candidate to attach the new type under. Validate against the supplied
+    # candidates (case-insensitive); a hallucinated or self-referential parent
+    # degrades to None so Sophia falls back to its default parent rather than
+    # grafting onto a dangling target (closed-world, mirrors `removed`).
+    label_norm = str(label).strip().lower()
+    parent_raw = data.get("parent")
+    graft_parent: Optional[str] = None
+    if isinstance(parent_raw, str):
+        cand_by_lower = {c.strip().lower(): c.strip() for c in request.candidates}
+        matched = cand_by_lower.get(parent_raw.strip().lower())
+        if matched and matched.lower() != label_norm:
+            graft_parent = matched
     return NameClusterResponse(
-        label=str(label).strip().lower(),
+        label=label_norm,
         description=str(data.get("description", "")),
         confidence=min(1.0, max(0.0, confidence)),
         removed=removed_ids,
+        parent=graft_parent,
     )
 
 

--- a/tests/test_name_cluster.py
+++ b/tests/test_name_cluster.py
@@ -172,3 +172,58 @@ def test_name_cluster_malformed_removed_degrades_not_500(monkeypatch):
     body = resp.json()
     assert body["label"] == "tree"
     assert body["removed"] == []
+
+
+def test_name_cluster_suggests_graft_parent(monkeypatch):
+    """On a coined-new label, Hermes returns a `parent` drawn from the
+    candidates so Sophia can graft the new type under it (concept/process
+    population)."""
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=512):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"label": "calculus", "confidence": 0.9, '
+                        '"parent": "concept"}'
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+    client = TestClient(m.app)
+    resp = client.post(
+        "/name-cluster",
+        json={
+            "members": [{"name": "derivative", "id": "n1"}],
+            "candidates": ["object", "concept"],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["parent"] == "concept"
+
+
+def test_name_cluster_rejects_unknown_parent(monkeypatch):
+    """A `parent` not among the supplied candidates degrades to None
+    (closed-world), so Sophia never grafts onto a dangling target."""
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=512):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"label": "calculus", "parent": "mathematics"}'
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+    client = TestClient(m.app)
+    resp = client.post(
+        "/name-cluster",
+        json={"members": [{"name": "x", "id": "n1"}], "candidates": ["concept"]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["parent"] is None

--- a/tests/test_name_cluster.py
+++ b/tests/test_name_cluster.py
@@ -227,3 +227,36 @@ def test_name_cluster_rejects_unknown_parent(monkeypatch):
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["parent"] is None
+
+
+def test_name_cluster_reuse_nulls_parent(monkeypatch):
+    """When `label` reuses an existing candidate, `parent` MUST be None even if
+    the LLM also returns one -- otherwise Sophia would try to graft an existing
+    type under a new parent. Only a NEWLY coined label carries a graft parent
+    (review #118: "null on reuse")."""
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=512):
+        return {
+            "choices": [
+                {
+                    "message": {
+                        # label == existing candidate "concept" (reuse), yet the
+                        # LLM still volunteers a parent; the contract must drop it.
+                        "content": '{"label": "concept", "parent": "object"}'
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+    client = TestClient(m.app)
+    resp = client.post(
+        "/name-cluster",
+        json={
+            "members": [{"name": "idea", "id": "n1"}],
+            "candidates": ["object", "concept"],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["label"] == "concept"
+    assert resp.json()["parent"] is None


### PR DESCRIPTION
## Summary
`/name-cluster` returns an optional `parent` when it coins a NEW label: the existing candidate to graft the new type under (closed-world, validated against the sent candidates; null on reuse or no sensible parent). Sophia's type-rollup consumes it to root the new super-type under the closest covering type.

## Changes
- `src/hermes/main.py` — `/name-cluster` returns an optional `parent`; closed-world validation + null-on-reuse guard
- `tests/test_name_cluster.py` — graft-parent, unknown-parent, and null-on-reuse regression tests

## Notes
Pins logos-foundry v0.7.3.
