### PR TITLE
feat: Hermes-internal canonicalize() + shared singularization core (#120)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1043,6 +1043,30 @@ perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3) ; python_version < \"3.9\"", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7) ; platform_python_implementation != \"PyPy\"", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1) ; platform_python_implementation != \"PyPy\"", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+description = "Correctly generate plurals, singular nouns, ordinals, indefinite articles"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344"},
+    {file = "inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f"},
+]
+
+[package.dependencies]
+more_itertools = ">=8.5.0"
+typeguard = ">=4.0.1"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["pygments", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy"]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
@@ -1426,10 +1450,9 @@ tqdm = "*"
 name = "more-itertools"
 version = "10.8.0"
 description = "More routines for operating on iterables, beyond itertools"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"ml\" or extra == \"ml-gpu\""
 files = [
     {file = "more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b"},
     {file = "more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd"},
@@ -4355,6 +4378,21 @@ tests = ["autopep8", "isort", "llnl-hatchet", "numpy", "pytest", "pytest-forked"
 tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
+name = "typeguard"
+version = "4.5.2"
+description = "Run-time type checker for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf"},
+    {file = "typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423"},
+]
+
+[package.dependencies]
+typing_extensions = ">=4.14.0"
+
+[[package]]
 name = "typer"
 version = "0.20.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -5035,4 +5073,4 @@ otel = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-instr
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "bb0eafa30cdaee65050fea74e7e52a62242f7c04c42818497f91e28e7281557d"
+content-hash = "17e500f36feb4841e39740ca3bb947098c0819231c1bfc2967d963c0589fe688"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "numpy>=1.24.0,<2.4",
   "redis>=5.0.0",
   "nltk>=3.8.0",
+  "inflect>=7.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -32,6 +32,7 @@ _INFLECT = inflect.engine()
 _IE_IRREGULARS = ("selfie", "smoothie", "hoodie", "foodie", "rottie", "hippie")
 for _ie in _IE_IRREGULARS:
     _INFLECT.defnoun(_ie, _ie + "s")
+del _ie
 
 # Latin -ix/-ices: inflect mis-singularizes (matrices -> matrice); pinned.
 _INFLECT.defnoun("matrix", "matrices")
@@ -97,10 +98,12 @@ def canonicalize(name: str) -> str:
     # Singularize the HEAD NOUN ONLY (the last token). Modifiers are untouched.
     tokens[-1] = singularize_word(tokens[-1])
 
-    # Strip a single trailing curated filler, but never empty the name.
-    if len(tokens) > 1 and tokens[-1] in _TRAILING_FILLERS:
+    # Strip trailing curated fillers -- looped, so stacked fillers
+    # ("vehicle type group") canonicalize in one pass -- but never empty the
+    # name: "type group" stops at "type".
+    while len(tokens) > 1 and tokens[-1] in _TRAILING_FILLERS:
         tokens = tokens[:-1]
-        # The stripped filler exposed a new head noun -- singularize it too,
+        # Each stripped filler exposes a new head noun -- singularize it too,
         # or "vehicles type" -> "vehicles" breaks canonicality + idempotence.
         tokens[-1] = singularize_word(tokens[-1])
 

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -33,6 +33,9 @@ _IE_IRREGULARS = ("selfie", "smoothie", "hoodie", "foodie", "rottie", "hippie")
 for _ie in _IE_IRREGULARS:
     _INFLECT.defnoun(_ie, _ie + "s")
 
+# Latin -ix/-ices: inflect mis-singularizes (matrices -> matrice); pinned.
+_INFLECT.defnoun("matrix", "matrices")
+
 # Leading articles dropped before head-noun singularization.
 _LEADING_ARTICLES = {"a", "an", "the"}
 

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -100,5 +100,8 @@ def canonicalize(name: str) -> str:
     # Strip a single trailing curated filler, but never empty the name.
     if len(tokens) > 1 and tokens[-1] in _TRAILING_FILLERS:
         tokens = tokens[:-1]
+        # The stripped filler exposed a new head noun -- singularize it too,
+        # or "vehicles type" -> "vehicles" breaks canonicality + idempotence.
+        tokens[-1] = singularize_word(tokens[-1])
 
     return " ".join(tokens)

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -1,0 +1,101 @@
+"""Canonical name normalization -- the single implementation, Hermes-internal.
+
+Normalization is Hermes' job (2026-06-05): ONE canonicalize() lives here and
+nowhere else. Sophia never normalizes -- the boundary contract is that every
+name entering the graph is already canonical, so the cognitive core compares
+names by exact match. The offline naming-driven-typing harness imports this
+module in-process (catalog-injection path A). Out-of-process callers that
+genuinely need normalization (migrations, apollo, audits) get a batch
+POST /normalize endpoint (deferred -- documented in the experiment plan),
+never a shared SDK symbol.
+
+Two exports:
+  singularize_word(word) -- the word-level core (inflect + keep-list +
+    suffix guard + defnoun irregulars). name_normalizer.py uses this for
+    entity/edge names, so types are NOT normalized differently than edges.
+  canonicalize(name) -- the type/cluster-name flavor: NFKC -> strip ->
+    collapse whitespace -> lowercase -> drop leading a/an/the -> singularize
+    HEAD NOUN ONLY -> strip curated trailing fillers, only when not the
+    whole string. Idempotent.
+"""
+
+import re
+import unicodedata
+
+import inflect
+
+# Single shared inflect engine (thread-safe for read-only singular_noun calls).
+_INFLECT = inflect.engine()
+
+# The -ie/-ies class inflect guesses wrong (-ies -> -y for unknown nouns).
+# Pinned irregulars: grow THIS list (and the golden table) -- never fork rules.
+_IE_IRREGULARS = ("selfie", "smoothie", "hoodie", "foodie", "rottie", "hippie")
+for _ie in _IE_IRREGULARS:
+    _INFLECT.defnoun(_ie, _ie + "s")
+
+# Leading articles dropped before head-noun singularization.
+_LEADING_ARTICLES = {"a", "an", "the"}
+
+# Curated trailing fillers stripped only when they are NOT the whole name.
+_TRAILING_FILLERS = {"type", "category", "kind", "class", "group", "entity"}
+
+# Words inflect mis-singularizes (over-strips); kept verbatim. Includes the
+# realm roots, structural keywords, and the SPEC golden cases.
+_SINGULAR_KEEP = {
+    "entity",
+    "concept",
+    "process",
+    "node",
+    "species",
+    "class",
+    "bus",
+    "analysis",
+}
+
+# Any word ending in one of these is already singular for our purposes;
+# inflect would wrongly strip the trailing s (e.g. -ss class/glass,
+# -is analysis/crisis, -us bus/corpus/status).
+_SINGULAR_SUFFIX_GUARD = ("ss", "is", "us")
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def singularize_word(word: str) -> str:
+    """Singularize a single already-lowercased token, conservatively.
+
+    The ONE word-level singularization core: inflect.singular_noun returns
+    False when the word is already singular; in that case (and for guarded
+    words) the input is kept unchanged. Consumed by canonicalize() here and
+    by name_normalizer._lemmatize_word (entity/edge flavor).
+    """
+    if word in _SINGULAR_KEEP or word.endswith(_SINGULAR_SUFFIX_GUARD):
+        return word
+    singular = _INFLECT.singular_noun(word)
+    return singular if isinstance(singular, str) else word
+
+
+def canonicalize(name: str) -> str:
+    """Return the canonical lowercase singular form of *name*.
+
+    Idempotent. Empty / whitespace-only input returns the empty string.
+    """
+    # NFKC -> strip -> collapse whitespace -> lowercase.
+    text = unicodedata.normalize("NFKC", name)
+    text = _WHITESPACE_RE.sub(" ", text).strip().lower()
+    if not text:
+        return ""
+
+    tokens = text.split(" ")
+
+    # Drop a single leading article (keep it if it is the whole string).
+    if len(tokens) > 1 and tokens[0] in _LEADING_ARTICLES:
+        tokens = tokens[1:]
+
+    # Singularize the HEAD NOUN ONLY (the last token). Modifiers are untouched.
+    tokens[-1] = singularize_word(tokens[-1])
+
+    # Strip a single trailing curated filler, but never empty the name.
+    if len(tokens) > 1 and tokens[-1] in _TRAILING_FILLERS:
+        tokens = tokens[:-1]
+
+    return " ".join(tokens)

--- a/src/hermes/name_normalizer.py
+++ b/src/hermes/name_normalizer.py
@@ -1,129 +1,29 @@
 """Post-extraction entity name normalization.
 
-Cleans entity names via lowercasing, lemmatization, and deduplication
-before they leave Hermes.  Uses NLTK WordNet for dictionary words and
-falls back to suffix rules for informal/slang terms not in WordNet.
+Cleans entity names via lowercasing, singularization, and deduplication
+before they leave Hermes.  Word-level singularization is delegated to the
+shared inflect-based core in ``hermes.canonical`` -- one engine for entity,
+edge, and type names.
 """
 
 from __future__ import annotations
 
 import logging
 
-import nltk
-from nltk.corpus import wordnet
-from nltk.stem import WordNetLemmatizer
+from hermes.canonical import singularize_word
 
 logger = logging.getLogger(__name__)
 
-# Ensure WordNet corpus is available (downloads once, ~3 MB).
-# In production, pre-bake the corpus into the container image.
-try:
-    nltk.data.find("corpora/wordnet")
-except LookupError:
-    nltk.download("wordnet", quiet=True)
-
-_wnl = WordNetLemmatizer()
-
-# ---------------------------------------------------------------------------
-# Suffix-rule fallback for words not in WordNet
-# ---------------------------------------------------------------------------
-_NO_STRIP_SUFFIXES = frozenset(
-    {
-        "ss",  # grass, lass, class
-        "us",  # bus, campus, virus
-        "is",  # analysis, basis, diabetes
-        "sis",  # thesis, crisis
-        "ous",  # dangerous, famous
-        "ics",  # physics, mathematics
-        "ies",  # handled separately by _ies rule
-    }
-)
-
-_VOWELS = frozenset("aeiou")
-
-
-def _singularize_fallback(word: str) -> str:
-    """Suffix-rule singularization for words not in WordNet.
-
-    Handles informal/slang plurals that the WordNet lemmatizer
-    returns unchanged (e.g. "rotties" -> "rottie").
-    Expects a lowercased input.
-    """
-    if len(word) <= 2:
-        return word
-
-    # -ies -> -ie (rotties -> rottie)
-    if word.endswith("ies") and len(word) > 4:
-        return word[:-3] + "ie"
-
-    # -sses -> -ss (grasses -> grass)
-    if word.endswith("sses"):
-        return word[:-2]
-
-    # -ches -> -ch, -shes -> -sh
-    if word.endswith("ches") or word.endswith("shes"):
-        return word[:-2]
-
-    # -xes -> -x (boxes -> box)
-    if word.endswith("xes"):
-        return word[:-2]
-
-    # -zes -> -z (fizzes -> fizz)
-    if word.endswith("zes") and len(word) > 4:
-        return word[:-2]
-
-    # Check exclusion suffixes before stripping bare -s
-    for suffix in _NO_STRIP_SUFFIXES:
-        if word.endswith(suffix):
-            return word
-
-    # -s after a consonant -> strip (dogs -> dog)
-    if word.endswith("s") and len(word) > 2 and word[-2] not in _VOWELS:
-        return word[:-1]
-
-    return word
-
-
-def _is_wordnet_lemma(word: str) -> bool:
-    """Check if *word* is itself a lemma form in WordNet (not just morphologically related)."""
-    try:
-        for ss in wordnet.synsets(word, pos="n"):
-            if word in [lemma.name() for lemma in ss.lemmas()]:
-                return True
-    except LookupError:
-        pass
-    return False
-
 
 def _lemmatize_word(word: str) -> str:
-    """Lemmatize a single word as a noun, with suffix-rule fallback.
+    """Singularize a single word via the shared core (hermes.canonical).
 
-    Guards against two classes of error:
-    1. Invariant nouns that WordNet incorrectly treats as plurals
-       (e.g. "species" -> "specie").  Detected by checking whether
-       the *original* word is itself a WordNet lemma.
-    2. Informal/slang words absent from WordNet (e.g. "rotties").
-       Handled by suffix-rule fallback.
+    One engine for entity, edge, AND type names (2026-06-05) -- no WordNet
+    fork. Words of length <= 2 are kept as-is.
     """
     if len(word) <= 2:
         return word
-    try:
-        lemma = _wnl.lemmatize(word, pos="n")
-    except LookupError:
-        return _singularize_fallback(word)
-    if lemma == word:
-        # WordNet didn't change it -- if it recognises the word as a
-        # noun it's already correct; only apply suffix rules for words
-        # WordNet doesn't know at all (e.g. "rotties").
-        if _is_wordnet_lemma(word):
-            return word
-        return _singularize_fallback(word)
-    # Lemmatizer changed the word.  But the original may itself be a
-    # valid lemma that WordNet incorrectly maps elsewhere
-    # (e.g. "species" -> "specie", "corps" -> "corp").
-    if _is_wordnet_lemma(word):
-        return word
-    return str(lemma)
+    return singularize_word(word)
 
 
 def _strip_possessive(word: str) -> str:

--- a/tests/unit/test_canonical.py
+++ b/tests/unit/test_canonical.py
@@ -1,0 +1,123 @@
+"""Frozen golden-table tests for the canonical name normalizer.
+
+ONE canonicalize() lives in Hermes (hermes.canonical) -- normalization is
+Hermes' job (2026-06-05). Sophia never normalizes: every name entering the
+graph is already canonical (canonical-at-the-boundary), and the offline
+naming-driven-typing harness imports this exact symbol in-process (path A).
+This golden table is FROZEN: every (input -> output) pair below is a
+contract. If a change here is intentional, it is a language-layer contract
+change -- update the table, the defnoun list, and the boundary consumers in
+the same PR.
+
+Behavior under test (SPEC s5.4 as amended 2026-06-05):
+NFKC -> strip -> collapse whitespace -> lowercase -> drop leading a/an/the ->
+singularize HEAD NOUN ONLY via the shared word-level core (inflect; keep-list
++ -ss/-is/-us suffix guard + defnoun irregulars for the -ie/-ies class) ->
+strip curated trailing fillers {type, category, kind, class, group, entity}
+only when not the whole string.
+canonicalize is idempotent: canonicalize(canonicalize(x)) == canonicalize(x).
+"""
+
+import pytest
+
+from hermes.canonical import canonicalize, singularize_word
+
+# FROZEN golden table -- the contract. (raw_input, canonical_output)
+GOLDEN: list[tuple[str, str]] = [
+    # plural -> singular head noun
+    ("vehicle", "vehicle"),
+    ("vehicles", "vehicle"),
+    ("mammal", "mammal"),
+    ("mammals", "mammal"),
+    ("process", "process"),
+    ("processes", "process"),
+    ("bus", "bus"),
+    ("buses", "bus"),
+    # inflect over-strips these -- keep-list / suffix guard must protect them
+    ("species", "species"),
+    ("analysis", "analysis"),
+    ("class", "class"),
+    # realm roots are stable fixed points
+    ("entity", "entity"),
+    ("concept", "concept"),
+    ("node", "node"),
+    # -ie/-ies class: defnoun irregulars (inflect's unknown--ies default is -y;
+    # these are the pinned exceptions -- grow the defnoun list, never fork rules)
+    ("selfie", "selfie"),
+    ("selfies", "selfie"),
+    ("smoothie", "smoothie"),
+    ("smoothies", "smoothie"),
+    ("hoodies", "hoodie"),
+    ("foodies", "foodie"),
+    ("rottie", "rottie"),
+    ("rotties", "rottie"),
+    ("hippies", "hippie"),
+    # unknown -ies defaults to -y (inflect) -- pinned so the convention is explicit
+    ("townies", "towny"),
+    # dictionary -ies words inflect already knows
+    ("cookies", "cookie"),
+    ("movies", "movie"),
+    ("ponies", "pony"),
+    ("cities", "city"),
+    # case / whitespace / unicode normalization
+    ("  Vehicle  ", "vehicle"),
+    ("VEHICLES", "vehicle"),
+    ("vehicle\xa0\xa0type", "vehicle"),  # NBSP collapses; trailing "type" stripped
+    # leading article stripping
+    ("the vehicle", "vehicle"),
+    ("a mammal", "mammal"),
+    ("an analysis", "analysis"),
+    # trailing filler stripping (only when not the whole string)
+    ("vehicle type", "vehicle"),
+    ("vehicle types", "vehicle"),
+    ("mammal category", "mammal"),
+    ("process group", "process"),
+    # whole-string filler is NOT stripped (would empty the name)
+    ("type", "type"),
+    ("category", "category"),
+    ("group", "group"),
+]
+
+
+@pytest.mark.parametrize("raw,expected", GOLDEN, ids=[g[0] for g in GOLDEN])
+def test_canonicalize_golden_table(raw: str, expected: str) -> None:
+    """Every frozen (input -> output) pair is a hard contract."""
+    assert canonicalize(raw) == expected
+
+
+@pytest.mark.parametrize("raw,expected", GOLDEN, ids=[g[0] for g in GOLDEN])
+def test_canonicalize_is_idempotent(raw: str, expected: str) -> None:
+    """canonicalize(canonicalize(x)) == canonicalize(x) for every golden input."""
+    once = canonicalize(raw)
+    assert canonicalize(once) == once
+    assert once == expected
+
+
+def test_vehicle_and_vehicles_collide() -> None:
+    """The harness relies on this collision for semantic reuse_collapses."""
+    assert canonicalize("vehicle") == canonicalize("vehicles")
+
+
+def test_ie_ies_defnoun_class_collides() -> None:
+    """Pinned -ie nouns: plural and singular collide (the rottie/rotty fix)."""
+    for singular, plural in [
+        ("selfie", "selfies"),
+        ("smoothie", "smoothies"),
+        ("rottie", "rotties"),
+        ("hippie", "hippies"),
+    ]:
+        assert canonicalize(plural) == canonicalize(singular) == singular
+
+
+def test_singularize_word_core_is_shared() -> None:
+    """The word-level core is exported for name_normalizer (one engine, no forks)."""
+    assert singularize_word("vehicles") == "vehicle"
+    assert singularize_word("rotties") == "rottie"
+    assert singularize_word("analysis") == "analysis"
+
+
+def test_empty_and_whitespace_only_return_empty() -> None:
+    """Degenerate inputs normalize to empty string, never raise."""
+    assert canonicalize("") == ""
+    assert canonicalize("   ") == ""
+    assert canonicalize("\xa0") == ""

--- a/tests/unit/test_canonical.py
+++ b/tests/unit/test_canonical.py
@@ -59,6 +59,9 @@ GOLDEN: list[tuple[str, str]] = [
     ("movies", "movie"),
     ("ponies", "pony"),
     ("cities", "city"),
+    # Latin -ix/-ices: pinned defnoun (inflect default gives "matrice")
+    ("matrix", "matrix"),
+    ("matrices", "matrix"),
     # case / whitespace / unicode normalization
     ("  Vehicle  ", "vehicle"),
     ("VEHICLES", "vehicle"),

--- a/tests/unit/test_canonical.py
+++ b/tests/unit/test_canonical.py
@@ -77,6 +77,13 @@ GOLDEN: list[tuple[str, str]] = [
     ("vehicles types", "vehicle"),
     ("mammal category", "mammal"),
     ("process group", "process"),
+    ("mammal kind", "mammal"),
+    ("vehicle class", "vehicle"),
+    ("dog entity", "dog"),
+    # stacked trailing fillers strip in a single pass (idempotence)
+    ("vehicle type group", "vehicle"),
+    ("vehicle types kinds", "vehicle"),
+    ("type group", "type"),
     # whole-string filler is NOT stripped (would empty the name)
     ("type", "type"),
     ("category", "category"),

--- a/tests/unit/test_canonical.py
+++ b/tests/unit/test_canonical.py
@@ -73,6 +73,8 @@ GOLDEN: list[tuple[str, str]] = [
     # trailing filler stripping (only when not the whole string)
     ("vehicle type", "vehicle"),
     ("vehicle types", "vehicle"),
+    ("vehicles type", "vehicle"),
+    ("vehicles types", "vehicle"),
     ("mammal category", "mammal"),
     ("process group", "process"),
     # whole-string filler is NOT stripped (would empty the name)

--- a/tests/unit/test_name_normalizer.py
+++ b/tests/unit/test_name_normalizer.py
@@ -164,9 +164,11 @@ class TestWordNetLemmatization:
         assert result[0]["name"] == "mouse"
 
     def test_irregular_people(self):
+        # Shared inflect core (hermes.canonical) singularizes the irregular:
+        # people -> person (the old WordNet path kept "people" verbatim).
         entities = [{"name": "People", "type": "entity", "start": 0, "end": 6}]
         result = normalize_entities(entities, "People")
-        assert result[0]["name"] == "people"
+        assert result[0]["name"] == "person"
 
     def test_irregular_wolves(self):
         entities = [{"name": "wolves", "type": "entity", "start": 0, "end": 6}]


### PR DESCRIPTION
## Summary
Adds the single source-of-truth name normalizer INSIDE Hermes (canonical-at-the-boundary; no foundry/SDK change): `hermes/canonical.py` exposes `singularize_word()` (inflect core + keep-list + -ss/-is/-us suffix guard + defnoun irregulars for the -ie/-ies class and `matrix/matrices`) and `canonicalize()` (type/cluster flavor: NFKC → ws-collapse → lower → article drop → head-noun singularize → trailing-filler strip; idempotent), pinned by a frozen golden-table CI test. `name_normalizer` swaps its WordNet lemma step for the same core — one engine for entity, edge, AND type names; the WordNet machinery leaves that module (nltk stays for /simple_nlp).

## Related Issue
Closes #120

## Changes
- Files / modules changed:
  - `src/hermes/canonical.py` (new) — core + canonicalize, defnoun irregulars
  - `tests/unit/test_canonical.py` (new) — frozen golden table (88 cases after matrix rows)
  - `src/hermes/name_normalizer.py` — `_lemmatize_word` delegates to the shared core; WordNet imports/fallback removed (−110 lines)
  - `tests/unit/test_name_normalizer.py` — one expectation updated: `people → person` (the core correctly singularizes the irregular; old WordNet path kept "people" as its own lemma)
  - `pyproject.toml` / `poetry.lock` — `inflect>=7.0.0`

## How to run / test locally

```bash
poetry install --extras dev
poetry run pytest tests/unit/test_canonical.py tests/unit/test_name_normalizer.py -v  # 135 passed
poetry run pytest tests/unit/ -q  # 230 passed, 2 skipped, 1 xfailed
```

## Checklist (required)
- [x] TDD red phase verified; golden table frozen (vehicle/vehicles collide; realm roots stable; rottie/selfie defnoun class)
- [x] Full unit suite green; ruff + black clean
- [x] Changed entity-test rows enumerated and justified (people→person; Rotties→rottie preserved)
- [x] PR references its issue

Part of epic c-daly/logos#553 (task T1). Spec: vault `sophia/plans/naming-driven-typing/` SPEC §5.4 as amended 2026-06-05.