### PR TITLE
feat: POST /type-cluster v2 — multi-group typing contract and validation (#121)

### DIFF
--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -25,7 +25,7 @@ load_dotenv()
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 try:
     from logos_config import get_env_value
@@ -1498,6 +1498,512 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
         confidence=min(1.0, max(0.0, confidence)),
         removed=removed_ids,
         parent=graft_parent,
+    )
+
+
+# ---------------------------------------------------------------------
+# v2 typing pass: POST /type-cluster (naming-driven typing experiment T4)
+#
+# Parallel to /name-cluster but catalog-aware: one LLM pass per cluster
+# emits a hypernym + IS_A chain to a realm root + reuse/mint decision per
+# subgroup. This module owns the contract + fail-closed server-side
+# validation only; the placement cascade lives in the offline harness.
+# The catalog is read from the module-level Redis-synced ``_type_registry``
+# (duck-typed: get_type_names() / get_type(name)); tests monkeypatch an
+# in-process stub (experiment path A).
+# ---------------------------------------------------------------------
+
+# The three realm roots every IS_A chain must terminate in.
+_TYPE_ROOTS: set[str] = {"entity", "concept", "process"}
+
+# Hard ceiling on chain length (the root link is always kept).
+_MAX_CHAIN: int = 8
+
+# Over-specification ceiling (computed on the RAW name, pre-canonicalize).
+MAX_WORDS: int = 3
+_OVER_SPEC_TOKENS: set[str] = {
+    "and",
+    "or",
+    "&",
+    "/",
+    "related",
+    "feature-of",
+    "part-of",
+    "with",
+}
+
+
+def _canonicalize_name(name: str) -> str:
+    """Canonicalize a type name to lowercase-singular form.
+
+    Prefers the shared implementation (``hermes.canonical.canonicalize``,
+    landed by T1 in this same package); falls back to an inline normalizer
+    with the same contract so this task stays testable before T1 merges.
+    The fallback is intentionally conservative (NFKC -> strip -> collapse
+    whitespace -> lowercase -> drop leading article -> naive head-noun
+    singularize with an irregular keep-list) and is idempotent.
+    """
+    try:
+        from hermes.canonical import canonicalize as _canon
+
+        return _canon(name)
+    except Exception:  # shared impl not on this branch yet; local fallback
+        import re
+        import unicodedata
+
+        text = unicodedata.normalize("NFKC", name or "").strip()
+        text = re.sub(r"\s+", " ", text).lower()
+        # drop a single leading article
+        text = re.sub(r"^(?:a|an|the)\s+", "", text)
+        if not text:
+            return text
+        words = text.split(" ")
+        head = words[-1]
+        keep = _TYPE_ROOTS | {
+            "node",
+            "species",
+            "analysis",
+            "class",
+            "bus",
+            "process",
+        }
+        if head not in keep and not head.endswith(("ss", "is", "us")):
+            if head.endswith("ies") and len(head) > 3:
+                head = head[:-3] + "y"
+            elif head.endswith("ses") and len(head) > 3:
+                head = head[:-2]
+            elif head.endswith("s") and len(head) > 1:
+                head = head[:-1]
+        words[-1] = head
+        return " ".join(words)
+
+
+def _is_over_specified(raw_name: str) -> bool:
+    """Ceiling check on the RAW name: >MAX_WORDS words OR a conjunction."""
+    lowered = (raw_name or "").strip().lower()
+    if not lowered:
+        return False
+    words = lowered.split()
+    if len(words) > MAX_WORDS:
+        return True
+    word_set = set(words)
+    for tok in _OVER_SPEC_TOKENS:
+        # whole-word match for word tokens; substring for symbols (& and /).
+        if tok.isalpha() or "-" in tok:
+            if tok in word_set:
+                return True
+        elif tok in lowered:
+            return True
+    return False
+
+
+def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
+    """Build the catalog system-prompt block + closed-world resolution maps.
+
+    Returns ``(catalog_block, alias_to_uuid, published_uuids, root_uuids)``.
+    Entries are sorted by (root, name) so the block is stable across requests
+    (prompt-cache friendly). Non-root types get bracketed short aliases
+    ``[t_xxxx]`` (the ``assign_to`` token, mapped back to a uuid server-side);
+    realm roots are listed GRAFT-ONLY and never receive an assignable alias.
+    With no registry installed everything is empty (catalog-agnostic mode).
+    """
+    registry = _type_registry
+    if registry is None:
+        return "", {}, set(), set()
+    try:
+        names = list(registry.get_type_names())
+    except Exception:
+        logger.warning("type_cluster: type registry unavailable; no catalog")
+        return "", {}, set(), set()
+    entries: list[dict[str, Any]] = []
+    for name in names:
+        info = registry.get_type(name)
+        if not isinstance(info, dict):
+            continue
+        type_uuid = info.get("uuid")
+        if not isinstance(type_uuid, str) or not type_uuid:
+            continue
+        entries.append(
+            {
+                "name": name,
+                "uuid": type_uuid,
+                "root": str(info.get("root") or ""),
+                "chain": info.get("chain"),
+                "is_root": bool(info.get("is_root")) or name in _TYPE_ROOTS,
+            }
+        )
+    entries.sort(key=lambda e: (e["root"], e["name"]))
+    published_uuids = {e["uuid"] for e in entries}
+    root_uuids = {e["uuid"] for e in entries if e["is_root"]}
+    alias_to_uuid: dict[str, str] = {}
+    lines = [
+        "PUBLISHED TYPE CATALOG (you may ONLY assign_to or graft onto an id below):"
+    ]
+    assignable = [e for e in entries if not e["is_root"]]
+    for idx, entry in enumerate(assignable):
+        alias = f"t_{idx:04d}"
+        alias_to_uuid[alias] = entry["uuid"]
+        entry_name = entry["name"]
+        entry_root = entry["root"] or "?"
+        line = f"  [{alias}] {entry_name} (root: {entry_root})"
+        chain = entry["chain"]
+        if isinstance(chain, list) and chain:
+            line += "  chain: " + " > ".join(str(c) for c in chain)
+        lines.append(line)
+    lines.append(
+        "GRAFT-ONLY ROOTS (valid as a parent in a chain, NEVER as "
+        "assign_to): entity, concept, process"
+    )
+    return "\n".join(lines), alias_to_uuid, published_uuids, root_uuids
+
+
+def _resolve_assign_to(
+    raw_assign: Any,
+    alias_to_uuid: dict[str, str],
+    published_uuids: set[str],
+    root_uuids: set[str],
+    has_catalog: bool,
+) -> str:
+    """Closed-world ``assign_to`` resolution (fail-closed; roots graft-only).
+
+    Bracketed ``[t_xxxx]`` aliases resolve through the injected catalog;
+    bare tokens must be published uuids when a catalog is present. Anything
+    unresolvable -- and anything resolving to a protected realm root -- is
+    coerced to the literal ``NEW``. Without a catalog the contract rule
+    applies: bracketed aliases are unresolvable (coerce), bare tokens are
+    accepted as already-resolved uuids.
+    """
+    if not isinstance(raw_assign, str):
+        return "NEW"
+    token = raw_assign.strip()
+    if not token or token == "NEW":
+        return "NEW"
+    if token.startswith("[") or token.endswith("]"):
+        alias = token.strip("[]").strip()
+        resolved = alias_to_uuid.get(alias)
+        if resolved is None:
+            logger.info(
+                "type_cluster: closed_world_coerce on unresolved alias %s",
+                token,
+            )
+            return "NEW"
+        if resolved in root_uuids:
+            logger.info("type_cluster: protected_root_coerce on assign_to %s", token)
+            return "NEW"
+        return resolved
+    if has_catalog:
+        if token not in published_uuids:
+            logger.info("type_cluster: closed_world_coerce on unknown uuid %s", token)
+            return "NEW"
+        if token in root_uuids:
+            logger.info("type_cluster: protected_root_coerce on assign_to %s", token)
+            return "NEW"
+        return token
+    return token
+
+
+class TypeClusterMember(BaseModel):
+    id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    hermes_type_hint: Optional[str] = None
+    neighbors: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class TypeClusterRequest(BaseModel):
+    members: List[TypeClusterMember] = Field(
+        ..., min_length=1, description="Cluster members to type (non-empty)"
+    )
+    request_id: Optional[str] = None
+    # catalog_k is OUT OF SCOPE for T4; null => full catalog (forward-compat).
+    catalog_k: Optional[int] = None
+
+    @field_validator("members")
+    @classmethod
+    def _member_ids_unique(
+        cls, value: List[TypeClusterMember]
+    ) -> List[TypeClusterMember]:
+        ids = [member.id for member in value]
+        if len(ids) != len(set(ids)):
+            raise ValueError("member ids must be unique (total partition over ids)")
+        return value
+
+
+class TypeGroup(BaseModel):
+    assign_to: str = Field(..., description="A published type uuid OR the literal NEW.")
+    name: str = Field(..., description="Canonical lowercase-singular hypernym.")
+    chain: List[str] = Field(
+        ...,
+        description=(
+            "IS_A chain SPECIFIC->GENERAL; chain[0]==name, " "chain[-1] a realm root."
+        ),
+    )
+    member_ids: List[str] = Field(default_factory=list)
+    confidence: float = 0.5
+    description: str = ""
+    over_specified: bool = False
+
+
+class TypeClusterResponse(BaseModel):
+    request_id: Optional[str] = None
+    groups: List[TypeGroup] = Field(default_factory=list)
+    residual_ids: List[str] = Field(default_factory=list)
+    raw_partition_ok: bool = True
+
+
+@app.post("/type-cluster", response_model=TypeClusterResponse)
+async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
+    """Type the categories that bind a cluster (naming-driven typing v2).
+
+    Sophia points (coarse cluster); Hermes asserts (per-subgroup hypernym +
+    IS_A chain to a realm root + reuse/mint decision). This handler owns the
+    contract and fail-closed server-side validation; the placement cascade
+    is simulated by the offline harness.
+    """
+    member_lines = []
+    for mem in request.members:
+        line = f"- {mem.name} (id: {mem.id})"
+        if mem.hermes_type_hint:
+            line += f" (hint: {mem.hermes_type_hint})"
+        member_lines.append(line)
+    members_block = "\n".join(member_lines)
+
+    (
+        catalog_block,
+        alias_to_uuid,
+        published_uuids,
+        root_uuids,
+    ) = _build_catalog_context()
+
+    system_msg = (
+        "You are an ontology typing assistant. Partition the cluster members "
+        "into one or more semantic subgroups. For each subgroup return a "
+        "canonical hypernym `name` (lowercase singular noun), an IS_A `chain` "
+        "from specific to general ending in exactly one realm root "
+        "(entity, concept, or process), `member_ids` (the EXACT input ids in "
+        "that subgroup), and `assign_to` (the bracketed id of an existing "
+        'published type to reuse, or the literal "NEW" to mint). Cover '
+        "EVERY input id exactly once across the subgroups; ids that fit "
+        "nothing go in top-level `residual_ids`. Return ONLY a JSON object: "
+        '{"groups": [{"assign_to": "<id-or-NEW>", "name": "<noun>", '
+        '"chain": ["<specific>", ..., "<root>"], '
+        '"member_ids": ["<id>", ...], "confidence": <0.0-1.0>, '
+        '"description": "<short>"}], "residual_ids": ["<id>", ...]}.'
+    )
+    if catalog_block:
+        system_msg += "\n\n" + catalog_block
+    user_msg = (
+        "These entities were grouped together (embedding-coarse cluster):\n"
+        f"{members_block}\n\nType them."
+    )
+
+    # max_tokens scales with member count so large clusters do not get the
+    # member_ids array clipped (truncation is a hard failure below).
+    max_tokens = min(4096, 512 + 24 * len(request.members))
+    result = await generate_completion(
+        messages=[
+            {"role": "system", "content": system_msg},
+            {"role": "user", "content": user_msg},
+        ],
+        temperature=0.0,
+        max_tokens=max_tokens,
+    )
+    choices = result.get("choices", [])
+    if not choices:
+        raise HTTPException(status_code=502, detail="LLM returned no choices")
+
+    content = choices[0]["message"]["content"]
+    # Truncation detection: a clipped member_ids tail makes the JSON
+    # unparseable. Surface it as a 502 (raw partition fidelity is gone)
+    # rather than letting a truncated tail masquerade as healthy residual
+    # backlog.
+    try:
+        data = _extract_json(content)
+    except Exception:
+        logger.warning("type_cluster: truncated_response (unparseable JSON)")
+        raise HTTPException(
+            status_code=502,
+            detail="LLM typing response was truncated/unparseable",
+        )
+    if not isinstance(data, dict):
+        raise HTTPException(
+            status_code=502, detail="LLM typing response is not a JSON object"
+        )
+
+    input_id_set = {mem.id for mem in request.members}
+
+    raw_groups = data.get("groups")
+    if not isinstance(raw_groups, list):
+        raw_groups = []
+    raw_residual = data.get("residual_ids")
+    if not isinstance(raw_residual, list):
+        raw_residual = []
+
+    # --- raw-fidelity bookkeeping (on the LLM output BEFORE reconcile) ---
+    raw_claimed: list[str] = []
+    raw_partition_ok = True
+    for g in raw_groups:
+        if not isinstance(g, dict):
+            raw_partition_ok = False
+            continue
+        gids = g.get("member_ids")
+        if not isinstance(gids, list):
+            raw_partition_ok = False
+            continue
+        raw_claimed.extend([gid for gid in gids if isinstance(gid, str)])
+    # subset: every raw-claimed id is a real input id
+    if any(gid not in input_id_set for gid in raw_claimed):
+        raw_partition_ok = False
+    # disjoint: no id claimed by two groups
+    if len(raw_claimed) != len(set(raw_claimed)):
+        raw_partition_ok = False
+    # total: raw group ids + returned residual cover every input id
+    raw_residual_in = {
+        r for r in raw_residual if isinstance(r, str) and r in input_id_set
+    }
+    if set(raw_claimed) | raw_residual_in != input_id_set:
+        raw_partition_ok = False
+
+    # --- reconciliation: first-claim wins, dedup, drop hallucinated ids ---
+    claimed: set[str] = set()
+    out_groups: list[TypeGroup] = []
+    for g in raw_groups:
+        if not isinstance(g, dict):
+            continue
+        raw_name = g.get("name")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            logger.warning("type_cluster: dropping group with missing name")
+            continue
+        gids_raw = g.get("member_ids")
+        if not isinstance(gids_raw, list):
+            gids_raw = []
+        kept_ids: list[str] = []
+        for gid in gids_raw:
+            if isinstance(gid, str) and gid in input_id_set and gid not in claimed:
+                claimed.add(gid)
+                kept_ids.append(gid)
+        if not kept_ids:
+            logger.warning(
+                "type_cluster: dropping group %s with no valid ids", raw_name
+            )
+            continue
+
+        # over_specified is computed on the RAW name, pre-canonicalize.
+        over_specified = _is_over_specified(raw_name)
+        canon_name = _canonicalize_name(raw_name)
+
+        # chain validation: canonicalize each link; de-dup consecutive
+        # repeats; append a deterministic root if missing; force
+        # chain[0] == name; cap length keeping the root. Never reject a
+        # group on a bad chain.
+        raw_chain = g.get("chain")
+        if not isinstance(raw_chain, list):
+            raw_chain = []
+        chain: list[str] = []
+        for link in raw_chain:
+            if not isinstance(link, str) or not link.strip():
+                continue
+            canon_link = _canonicalize_name(link)
+            if not chain or chain[-1] != canon_link:
+                chain.append(canon_link)
+        if not chain or chain[-1] not in _TYPE_ROOTS:
+            chain.append("entity")  # deterministic default realm root
+            logger.warning(
+                "type_cluster: bad_root -- appended default root for %s",
+                canon_name,
+            )
+        if chain[0] != canon_name:
+            chain = [canon_name] + chain
+        if len(chain) > _MAX_CHAIN:
+            chain = chain[: _MAX_CHAIN - 1] + [chain[-1]]
+
+        assign_to = _resolve_assign_to(
+            g.get("assign_to"),
+            alias_to_uuid,
+            published_uuids,
+            root_uuids,
+            has_catalog=_type_registry is not None,
+        )
+
+        try:
+            confidence = float(g.get("confidence", 0.5))
+        except (TypeError, ValueError):
+            confidence = 0.5
+        confidence = max(0.0, min(1.0, confidence))
+
+        description = g.get("description", "")
+        if not isinstance(description, str):
+            description = ""
+
+        out_groups.append(
+            TypeGroup(
+                assign_to=assign_to,
+                name=canon_name,
+                chain=chain,
+                member_ids=kept_ids,
+                confidence=confidence,
+                description=description,
+                over_specified=over_specified,
+            )
+        )
+
+    if not out_groups:
+        raise HTTPException(
+            status_code=502,
+            detail="LLM typing response contained no usable groups",
+        )
+
+    # Intra-response canonical-name merge: groups are merged ONLY when the
+    # canonical name AND the proposed chain[-1] root both collide (union
+    # member_ids, keep the higher-confidence chain); different roots stay
+    # split (homonym guard).
+    merged: dict[tuple[str, str], TypeGroup] = {}
+    merged_order: list[tuple[str, str]] = []
+    for grp in out_groups:
+        key = (grp.name, grp.chain[-1])
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = grp
+            merged_order.append(key)
+            continue
+        winner = grp if grp.confidence > existing.confidence else existing
+        merged[key] = TypeGroup(
+            assign_to=winner.assign_to,
+            name=winner.name,
+            chain=list(winner.chain),
+            member_ids=existing.member_ids + grp.member_ids,
+            confidence=winner.confidence,
+            description=winner.description,
+            over_specified=existing.over_specified or grp.over_specified,
+        )
+        logger.info(
+            "type_cluster: merged duplicate canonical group %s (root %s)",
+            key[0],
+            key[1],
+        )
+    out_groups = [merged[k] for k in merged_order]
+
+    # residual = (input - claimed) | (returned residual within input - claimed)
+    residual_ids = sorted((input_id_set - claimed) | (raw_residual_in - claimed))
+
+    # Final safety assert: groups disjoint-union residual == input ids
+    # (failure here is a server bug => 500).
+    final_union: set[str] = set()
+    for grp in out_groups:
+        final_union |= set(grp.member_ids)
+    if (
+        final_union & set(residual_ids)
+        or (final_union | set(residual_ids)) != input_id_set
+    ):
+        logger.error("type_cluster: post-reconcile partition broken")
+        raise HTTPException(
+            status_code=500, detail="typing partition invariant violated"
+        )
+
+    return TypeClusterResponse(
+        request_id=request.request_id,
+        groups=out_groups,
+        residual_ids=residual_ids,
+        raw_partition_ok=raw_partition_ok,
     )
 
 

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -124,6 +124,7 @@ from starlette.middleware.base import (
 from starlette.responses import Response as StarletteResponse
 
 from hermes import __version__, milvus_client
+from hermes.canonical import canonicalize
 from hermes.context_cache import ContextCache
 from hermes.llm import (
     LLMProviderError,
@@ -1533,51 +1534,6 @@ _OVER_SPEC_TOKENS: set[str] = {
 }
 
 
-def _canonicalize_name(name: str) -> str:
-    """Canonicalize a type name to lowercase-singular form.
-
-    Prefers the shared implementation (``hermes.canonical.canonicalize``,
-    landed by T1 in this same package); falls back to an inline normalizer
-    with the same contract so this task stays testable before T1 merges.
-    The fallback is intentionally conservative (NFKC -> strip -> collapse
-    whitespace -> lowercase -> drop leading article -> naive head-noun
-    singularize with an irregular keep-list) and is idempotent.
-    """
-    try:
-        from hermes.canonical import canonicalize as _canon
-
-        return _canon(name)
-    except Exception:  # shared impl not on this branch yet; local fallback
-        import re
-        import unicodedata
-
-        text = unicodedata.normalize("NFKC", name or "").strip()
-        text = re.sub(r"\s+", " ", text).lower()
-        # drop a single leading article
-        text = re.sub(r"^(?:a|an|the)\s+", "", text)
-        if not text:
-            return text
-        words = text.split(" ")
-        head = words[-1]
-        keep = _TYPE_ROOTS | {
-            "node",
-            "species",
-            "analysis",
-            "class",
-            "bus",
-            "process",
-        }
-        if head not in keep and not head.endswith(("ss", "is", "us")):
-            if head.endswith("ies") and len(head) > 3:
-                head = head[:-3] + "y"
-            elif head.endswith("ses") and len(head) > 3:
-                head = head[:-2]
-            elif head.endswith("s") and len(head) > 1:
-                head = head[:-1]
-        words[-1] = head
-        return " ".join(words)
-
-
 def _is_over_specified(raw_name: str) -> bool:
     """Ceiling check on the RAW name: >MAX_WORDS words OR a conjunction."""
     lowered = (raw_name or "").strip().lower()
@@ -1650,9 +1606,10 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
         if isinstance(chain, list) and chain:
             line += "  chain: " + " > ".join(str(c) for c in chain)
         lines.append(line)
+    roots_csv = ", ".join(sorted(_TYPE_ROOTS))
     lines.append(
         "GRAFT-ONLY ROOTS (valid as a parent in a chain, NEVER as "
-        "assign_to): entity, concept, process"
+        f"assign_to): {roots_csv}"
     )
     return "\n".join(lines), alias_to_uuid, published_uuids, root_uuids
 
@@ -1773,6 +1730,9 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         published_uuids,
         root_uuids,
     ) = _build_catalog_context()
+    # Part of the catalog snapshot: capture once here instead of
+    # re-reading the live _type_registry global per group below.
+    has_catalog = _type_registry is not None
 
     system_msg = (
         "You are an ontology typing assistant. Partition the cluster members "
@@ -1889,7 +1849,7 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
 
         # over_specified is computed on the RAW name, pre-canonicalize.
         over_specified = _is_over_specified(raw_name)
-        canon_name = _canonicalize_name(raw_name)
+        canon_name = canonicalize(raw_name)
 
         # chain validation: canonicalize each link; de-dup consecutive
         # repeats; append a deterministic root if missing; force
@@ -1902,7 +1862,7 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         for link in raw_chain:
             if not isinstance(link, str) or not link.strip():
                 continue
-            canon_link = _canonicalize_name(link)
+            canon_link = canonicalize(link)
             if not chain or chain[-1] != canon_link:
                 chain.append(canon_link)
         if not chain or chain[-1] not in _TYPE_ROOTS:
@@ -1912,7 +1872,14 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
                 canon_name,
             )
         if chain[0] != canon_name:
-            chain = [canon_name] + chain
+            if canon_name in chain:
+                # canon_name already appears deeper in the chain: slice
+                # from its first occurrence (dropping the more-specific
+                # prefix) so the SPEC 5.2 graft walk never sees a
+                # non-consecutive duplicate of the name.
+                chain = chain[chain.index(canon_name) :]
+            else:
+                chain = [canon_name] + chain
         if len(chain) > _MAX_CHAIN:
             chain = chain[: _MAX_CHAIN - 1] + [chain[-1]]
 
@@ -1921,7 +1888,7 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
             alias_to_uuid,
             published_uuids,
             root_uuids,
-            has_catalog=_type_registry is not None,
+            has_catalog=has_catalog,
         )
 
         try:
@@ -1982,8 +1949,10 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         )
     out_groups = [merged[k] for k in merged_order]
 
-    # residual = (input - claimed) | (returned residual within input - claimed)
-    residual_ids = sorted((input_id_set - claimed) | (raw_residual_in - claimed))
+    # residual = input ids never claimed by a kept group. Set-equivalent
+    # to the SPEC 3.4 union (input - claimed) | (raw_residual_in - claimed)
+    # because raw_residual_in is filtered to input_id_set above.
+    residual_ids = sorted(input_id_set - claimed)
 
     # Final safety assert: groups disjoint-union residual == input ids
     # (failure here is a server bug => 500).

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -208,6 +208,34 @@ def test_type_cluster_chain_root_appended_when_missing(monkeypatch):
     assert chain[-1] in {"entity", "concept", "process"}
 
 
+def test_type_cluster_chain_sliced_from_existing_name_occurrence(monkeypatch):
+    """A canon name already mid-chain slices the chain from that occurrence.
+
+    Naive prepend would mint a non-consecutive duplicate
+    (vehicle > car > vehicle > ...); slicing drops the more-specific
+    prefix and keeps the general tail intact.
+    """
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "NEW",
+                    "name": "vehicle",
+                    "chain": ["car", "vehicle", "machine", "entity"],
+                    "member_ids": ["i1"],
+                }
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
+    assert resp.status_code == 200, resp.text
+    chain = resp.json()["groups"][0]["chain"]
+    assert chain == ["vehicle", "machine", "entity"]
+
+
 def test_type_cluster_over_specified_flag(monkeypatch):
     """A conjunction / too-many-words RAW name sets over_specified on the group."""
     content = json.dumps(
@@ -263,12 +291,12 @@ def test_type_cluster_assign_to_unresolvable_coerced_new(monkeypatch):
     assert resp.json()["groups"][0]["assign_to"] == "NEW"
 
 
-def test_canonicalize_name_wrapper_lowercases_and_singularizes():
-    """_canonicalize_name is idempotent and collapses vehicle/vehicles."""
-    assert m._canonicalize_name("Vehicles") == "vehicle"
-    assert m._canonicalize_name("vehicle") == "vehicle"
-    assert m._canonicalize_name(m._canonicalize_name("Vehicles")) == "vehicle"
-    assert m._canonicalize_name("process") == "process"
+def test_canonicalize_name_lowercases_and_singularizes():
+    """The shared canonicalize impl is idempotent and collapses vehicle/vehicles."""
+    assert m.canonicalize("Vehicles") == "vehicle"
+    assert m.canonicalize("vehicle") == "vehicle"
+    assert m.canonicalize(m.canonicalize("Vehicles")) == "vehicle"
+    assert m.canonicalize("process") == "process"
 
 
 def test_type_cluster_duplicate_member_ids_is_422():

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -1,0 +1,463 @@
+"""Tests for the v2 /type-cluster endpoint (naming-driven typing experiment T4).
+
+Every test monkeypatches generate_completion -- no live LLM calls. The endpoint
+contract and server-side validation are exercised in isolation; where a test
+needs a catalog it injects an in-process stub TypeRegistry (experiment path A).
+The placement cascade lives in later tasks.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import hermes.main as m
+from fastapi.testclient import TestClient
+
+
+def _make_completion(content: str):
+    """Build a fake generate_completion returning *content* as the LLM message."""
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=512):
+        return {"choices": [{"message": {"content": content}}]}
+
+    return fake_completion
+
+
+class _StubTypeRegistry:
+    """Minimal in-process TypeRegistry stub (experiment path A)."""
+
+    def __init__(self, types: dict[str, dict[str, Any]]) -> None:
+        self._types = types
+
+    def get_type_names(self) -> list[str]:
+        return sorted(self._types)
+
+    def get_type(self, name: str) -> dict[str, Any] | None:
+        info = self._types.get(name)
+        return dict(info) if info is not None else None
+
+
+def test_type_cluster_happy_path_partitions_ids(monkeypatch):
+    """A well-formed two-group response round-trips, partitions all ids, and is clean."""
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "NEW",
+                    "name": "Vehicles",
+                    "chain": ["Vehicle", "Entity"],
+                    "member_ids": ["i1", "i2"],
+                    "confidence": 0.9,
+                    "description": "wheeled",
+                },
+                {
+                    "assign_to": "NEW",
+                    "name": "Mammal",
+                    "chain": ["mammal", "animal", "entity"],
+                    "member_ids": ["i3"],
+                },
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post(
+        "/type-cluster",
+        json={
+            "members": [
+                {"id": "i1", "name": "car"},
+                {"id": "i2", "name": "truck"},
+                {"id": "i3", "name": "dog"},
+            ],
+            "request_id": "req-1",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["request_id"] == "req-1"
+    assert body["raw_partition_ok"] is True
+    assert body["residual_ids"] == []
+    groups = body["groups"]
+    assert len(groups) == 2
+    # name + chain entries are canonicalized (lowercase singular); chain[0]==name.
+    g0 = groups[0]
+    assert g0["name"] == "vehicle"
+    assert g0["chain"][0] == "vehicle"
+    assert g0["chain"][-1] == "entity"
+    assert g0["member_ids"] == ["i1", "i2"]
+    assert g0["over_specified"] is False
+    # total partition: every input id is claimed exactly once across groups+residual.
+    claimed = [mid for g in groups for mid in g["member_ids"]] + body["residual_ids"]
+    assert sorted(claimed) == ["i1", "i2", "i3"]
+
+
+def test_type_cluster_empty_members_is_422():
+    """An empty cluster is a request-validation 422, not a fabricated typing."""
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": []})
+    assert resp.status_code == 422, resp.text
+
+
+def test_type_cluster_non_dict_llm_is_502(monkeypatch):
+    """A non-object JSON payload from the LLM surfaces as a 502 (bad upstream shape)."""
+    monkeypatch.setattr(
+        m, "generate_completion", _make_completion(json.dumps(["not", "a", "dict"]))
+    )
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "x"}]})
+    assert resp.status_code == 502, resp.text
+
+
+def test_type_cluster_truncated_member_ids_is_502(monkeypatch):
+    """A clipped member_ids array (truncated tail) => raw_partition_ok False => 502."""
+    # Clip the closing brackets so the first-{/last-} fallback of _extract_json
+    # also fails (no closing brace remains anywhere in the payload).
+    full = json.dumps({"groups": [{"name": "vehicle", "member_ids": ["i1", "i2"]}]})
+    truncated = full[:-4]
+    monkeypatch.setattr(m, "generate_completion", _make_completion(truncated))
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "x"}]})
+    assert resp.status_code == 502, resp.text
+
+
+def test_type_cluster_unclaimed_ids_become_residual_and_flag_raw(monkeypatch):
+    """Ids the LLM omits land in residual_ids; raw_partition_ok is False (not total)."""
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "NEW",
+                    "name": "vehicle",
+                    "chain": ["vehicle", "entity"],
+                    "member_ids": ["i1"],
+                }
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post(
+        "/type-cluster",
+        json={"members": [{"id": "i1", "name": "car"}, {"id": "i2", "name": "truck"}]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["residual_ids"] == ["i2"]
+    assert body["raw_partition_ok"] is False
+
+
+def test_type_cluster_hallucinated_and_duplicate_ids_dropped(monkeypatch):
+    """Unknown ids are dropped; a re-claimed id goes to its first group (first-claim wins)."""
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "NEW",
+                    "name": "vehicle",
+                    "chain": ["vehicle", "entity"],
+                    "member_ids": ["i1", "i1", "ghost"],
+                },
+                {
+                    "assign_to": "NEW",
+                    "name": "animal",
+                    "chain": ["animal", "entity"],
+                    "member_ids": ["i1", "i2"],
+                },
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post(
+        "/type-cluster",
+        json={"members": [{"id": "i1", "name": "car"}, {"id": "i2", "name": "dog"}]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    groups = body["groups"]
+    assert groups[0]["member_ids"] == ["i1"]  # dedup + first-claim, ghost dropped
+    assert groups[1]["member_ids"] == ["i2"]  # i1 already claimed by group 0
+    assert body["raw_partition_ok"] is False  # raw output was not disjoint
+
+
+def test_type_cluster_chain_root_appended_when_missing(monkeypatch):
+    """A chain not terminating in a realm root gets a deterministic root appended."""
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "NEW",
+                    "name": "sedan",
+                    "chain": ["sedan", "vehicle"],
+                    "member_ids": ["i1"],
+                }
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
+    assert resp.status_code == 200, resp.text
+    chain = resp.json()["groups"][0]["chain"]
+    assert chain[0] == "sedan"
+    assert chain[-1] in {"entity", "concept", "process"}
+
+
+def test_type_cluster_over_specified_flag(monkeypatch):
+    """A conjunction / too-many-words RAW name sets over_specified on the group."""
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "NEW",
+                    "name": "cars and trucks",
+                    "chain": ["vehicle", "entity"],
+                    "member_ids": ["i1"],
+                }
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["groups"][0]["over_specified"] is True
+
+
+def test_type_cluster_all_groups_invalid_is_502(monkeypatch):
+    """Every group missing name/member_ids => nothing usable => 502."""
+    content = json.dumps(
+        {"groups": [{"name": "", "member_ids": []}], "residual_ids": []}
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "x"}]})
+    assert resp.status_code == 502, resp.text
+
+
+def test_type_cluster_assign_to_unresolvable_coerced_new(monkeypatch):
+    """A bracketed alias that does not resolve against the catalog coerces to NEW."""
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "[nope-uuid]",
+                    "name": "vehicle",
+                    "chain": ["vehicle", "entity"],
+                    "member_ids": ["i1"],
+                }
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["groups"][0]["assign_to"] == "NEW"
+
+
+def test_canonicalize_name_wrapper_lowercases_and_singularizes():
+    """_canonicalize_name is idempotent and collapses vehicle/vehicles."""
+    assert m._canonicalize_name("Vehicles") == "vehicle"
+    assert m._canonicalize_name("vehicle") == "vehicle"
+    assert m._canonicalize_name(m._canonicalize_name("Vehicles")) == "vehicle"
+    assert m._canonicalize_name("process") == "process"
+
+
+def test_type_cluster_duplicate_member_ids_is_422():
+    """Duplicate member ids break the total-partition contract => 422."""
+    client = TestClient(m.app)
+    resp = client.post(
+        "/type-cluster",
+        json={
+            "members": [
+                {"id": "i1", "name": "car"},
+                {"id": "i1", "name": "truck"},
+            ]
+        },
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_type_cluster_alias_assign_resolves_against_stub_catalog(monkeypatch):
+    """A bracketed [t_xxxx] alias resolves to the published uuid it aliases."""
+    stub = _StubTypeRegistry(
+        {
+            "vehicle": {
+                "uuid": "type_vehicle_aaaa1111",
+                "root": "entity",
+                "chain": ["vehicle", "entity"],
+            }
+        }
+    )
+    monkeypatch.setattr(m, "_type_registry", stub)
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "[t_0000]",
+                    "name": "vehicle",
+                    "chain": ["vehicle", "entity"],
+                    "member_ids": ["i1"],
+                }
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["groups"][0]["assign_to"] == "type_vehicle_aaaa1111"
+
+
+def test_type_cluster_protected_root_assign_coerced_new(monkeypatch):
+    """assign_to resolving to a realm root uuid coerces to NEW (graft-only roots)."""
+    stub = _StubTypeRegistry(
+        {
+            "entity": {"uuid": "type_entity_root0001", "is_root": True},
+            "vehicle": {"uuid": "type_vehicle_aaaa1111", "root": "entity"},
+        }
+    )
+    monkeypatch.setattr(m, "_type_registry", stub)
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "type_entity_root0001",
+                    "name": "vehicle",
+                    "chain": ["vehicle", "entity"],
+                    "member_ids": ["i1"],
+                }
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["groups"][0]["assign_to"] == "NEW"
+
+
+def test_type_cluster_homonym_groups_not_merged(monkeypatch):
+    """Same canonical name under DIFFERENT proposed roots stays two groups."""
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "NEW",
+                    "name": "bank",
+                    "chain": ["bank", "entity"],
+                    "member_ids": ["i1"],
+                },
+                {
+                    "assign_to": "NEW",
+                    "name": "bank",
+                    "chain": ["bank", "concept"],
+                    "member_ids": ["i2"],
+                },
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post(
+        "/type-cluster",
+        json={
+            "members": [
+                {"id": "i1", "name": "river bank"},
+                {"id": "i2", "name": "trust"},
+            ]
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    groups = resp.json()["groups"]
+    assert len(groups) == 2
+    assert {g["chain"][-1] for g in groups} == {"entity", "concept"}
+
+
+def test_type_cluster_same_name_same_root_groups_merged(monkeypatch):
+    """Same canonical name AND same proposed root merge: union ids, best chain."""
+    content = json.dumps(
+        {
+            "groups": [
+                {
+                    "assign_to": "NEW",
+                    "name": "vehicle",
+                    "chain": ["vehicle", "entity"],
+                    "member_ids": ["i1"],
+                    "confidence": 0.6,
+                },
+                {
+                    "assign_to": "NEW",
+                    "name": "Vehicles",
+                    "chain": ["vehicle", "conveyance", "entity"],
+                    "member_ids": ["i2"],
+                    "confidence": 0.9,
+                },
+            ],
+            "residual_ids": [],
+        }
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    client = TestClient(m.app)
+    resp = client.post(
+        "/type-cluster",
+        json={"members": [{"id": "i1", "name": "car"}, {"id": "i2", "name": "truck"}]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    groups = body["groups"]
+    assert len(groups) == 1
+    assert groups[0]["member_ids"] == ["i1", "i2"]
+    assert groups[0]["confidence"] == 0.9
+    assert groups[0]["chain"] == ["vehicle", "conveyance", "entity"]
+    assert body["residual_ids"] == []
+    assert body["raw_partition_ok"] is True
+
+
+def test_type_cluster_catalog_block_in_system_prompt(monkeypatch):
+    """The catalog block (aliases + GRAFT-ONLY roots) lands in the SYSTEM prompt."""
+    stub = _StubTypeRegistry(
+        {"vehicle": {"uuid": "type_vehicle_aaaa1111", "root": "entity"}}
+    )
+    monkeypatch.setattr(m, "_type_registry", stub)
+    captured: dict[str, Any] = {}
+
+    async def fake_completion(messages, temperature=0.0, max_tokens=512):
+        captured["messages"] = messages
+        captured["temperature"] = temperature
+        content = json.dumps(
+            {
+                "groups": [
+                    {
+                        "assign_to": "NEW",
+                        "name": "vehicle",
+                        "chain": ["vehicle", "entity"],
+                        "member_ids": ["i1"],
+                    }
+                ],
+                "residual_ids": [],
+            }
+        )
+        return {"choices": [{"message": {"content": content}}]}
+
+    monkeypatch.setattr(m, "generate_completion", fake_completion)
+    client = TestClient(m.app)
+    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
+    assert resp.status_code == 200, resp.text
+    system = captured["messages"][0]
+    assert system["role"] == "system"
+    assert "PUBLISHED TYPE CATALOG" in system["content"]
+    assert "[t_0000] vehicle" in system["content"]
+    assert "GRAFT-ONLY ROOTS" in system["content"]
+    assert captured["temperature"] == 0.0


### PR DESCRIPTION
## Summary
New catalog-aware multi-group typing endpoint per SPEC §3 — v1 `/name-cluster` is byte-untouched and coexists. `POST /type-cluster`: members with required unique ids (422 on dup/empty), system-prompt catalog block from TypeRegistry (`[t_xxxx]` aliases, roots GRAFT-ONLY), temperature 0.0 with member-count-sized max_tokens and explicit truncation → 502 (never silent residual). Fail-closed validation: id closed-world + total partition over ids (first-claim-wins reconciliation; `raw_partition_ok` preserved as the pre-reconciliation fidelity signal), post-reconciliation disjoint-union assert → 500, closed-world `assign_to` with protected-root coerce-to-NEW, chain canonicalization (`hermes.canonical` with local fallback until #124 merges) + dedup + root-append + cap-8, intra-response merge gated on (canonical name AND proposed terminal root) — the homonym guard. Drivable in-process with a stub TypeRegistry (the experiment's path A).

## Related Issue
Closes #121

## Changes
- Files / modules changed:
  - `src/hermes/main.py` — additive block after the v1 route: constants, `_canonicalize_name`, `_is_over_specified`, `_build_catalog_context`, `_resolve_assign_to`, request/response models, the route (+970/−1; the one modified line is the pydantic import)
  - `tests/test_type_cluster.py` (new) — 17 contract tests, monkeypatched `generate_completion` (no live LLM)

## How to run / test locally

```bash
poetry install --extras dev
poetry run pytest tests/test_type_cluster.py -v          # 17 passed
poetry run pytest tests/ -q --ignore=tests/e2e --ignore=tests/integration  # 184 passed
```

## Checklist (required)
- [x] TDD red phase verified (17 failed pre-implementation)
- [x] v1 /name-cluster untouched (27 passed combined; diff purely additive)
- [x] ruff + black clean
- [x] PR references its issue

Part of epic c-daly/logos#553 (task T4). `_canonicalize_name`'s local fallback drops when #124 merges.