### PR TITLE
fix(type-cluster): revert to the as-designed name + outliers contract (#127)

### DIFF
--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1514,8 +1514,12 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
 # in-process stub (experiment path A).
 # ---------------------------------------------------------------------
 
-# The three realm roots every IS_A chain must terminate in.
-_TYPE_ROOTS: set[str] = {"entity", "concept", "process"}
+# Structural scaffolding above the domain roots: never published in the
+# catalog and never a valid `parent`. The domain roots themselves
+# (entity/concept/process) are ordinary catalog citizens. `cognition` is not
+# minted in the current design, so it is excluded from the catalog as well.
+_STRUCTURAL_ROOTS: set[str] = {"node", "root"}
+_CATALOG_EXCLUDED: set[str] = _STRUCTURAL_ROOTS | {"cognition"}
 
 # Hard ceiling on chain length (the root link is always kept).
 _MAX_CHAIN: int = 8
@@ -1556,12 +1560,14 @@ def _is_over_specified(raw_name: str) -> bool:
 def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
     """Build the catalog system-prompt block + closed-world resolution maps.
 
-    Returns ``(catalog_block, alias_to_uuid, published_uuids, root_uuids)``.
+    Returns ``(catalog_block, alias_to_uuid, published_uuids, catalog_names)``.
     Entries are sorted by (root, name) so the block is stable across requests
-    (prompt-cache friendly). Non-root types get bracketed short aliases
-    ``[t_xxxx]`` (the ``assign_to`` token, mapped back to a uuid server-side);
-    realm roots are listed GRAFT-ONLY and never receive an assignable alias.
-    With no registry installed everything is empty (catalog-agnostic mode).
+    (prompt-cache friendly). Every published type -- the domain roots
+    (entity/concept/process) included -- is an ordinary entry with a bracketed
+    short alias ``[t_xxxx]``, valid both as a `parent` choice and as an honest
+    `name` reuse. Only the structural scaffolding above the roots (``node``,
+    ``root``) and the unminted ``cognition`` are excluded. With no registry
+    installed everything is empty (catalog-agnostic mode).
     """
     registry = _type_registry
     if registry is None:
@@ -1573,6 +1579,8 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
         return "", {}, set(), set()
     entries: list[dict[str, Any]] = []
     for name in names:
+        if name.strip().lower() in _CATALOG_EXCLUDED:
+            continue
         info = registry.get_type(name)
         if not isinstance(info, dict):
             continue
@@ -1585,18 +1593,17 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
                 "uuid": type_uuid,
                 "root": str(info.get("root") or ""),
                 "chain": info.get("chain"),
-                "is_root": bool(info.get("is_root")) or name in _TYPE_ROOTS,
             }
         )
     entries.sort(key=lambda e: (e["root"], e["name"]))
     published_uuids = {e["uuid"] for e in entries}
-    root_uuids = {e["uuid"] for e in entries if e["is_root"]}
+    catalog_names = {canonicalize(str(e["name"])) for e in entries}
     alias_to_uuid: dict[str, str] = {}
     lines = [
-        "PUBLISHED TYPE CATALOG (you may ONLY assign_to or graft onto an id below):"
+        "PUBLISHED TYPE CATALOG (the existing types: reuse one as `name`, "
+        "or pick one as the `parent` of a new type):"
     ]
-    assignable = [e for e in entries if not e["is_root"]]
-    for idx, entry in enumerate(assignable):
+    for idx, entry in enumerate(entries):
         alias = f"t_{idx:04d}"
         alias_to_uuid[alias] = entry["uuid"]
         entry_name = entry["name"]
@@ -1606,57 +1613,36 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
         if isinstance(chain, list) and chain:
             line += "  chain: " + " > ".join(str(c) for c in chain)
         lines.append(line)
-    roots_csv = ", ".join(sorted(_TYPE_ROOTS))
-    lines.append(
-        "GRAFT-ONLY ROOTS (valid as a parent in a chain, NEVER as "
-        f"assign_to): {roots_csv}"
-    )
-    return "\n".join(lines), alias_to_uuid, published_uuids, root_uuids
+    return "\n".join(lines), alias_to_uuid, published_uuids, catalog_names
 
 
-def _resolve_assign_to(
-    raw_assign: Any,
-    alias_to_uuid: dict[str, str],
-    published_uuids: set[str],
-    root_uuids: set[str],
+def _resolve_parent(
+    raw_parent: Any,
+    catalog_names: set[str],
     has_catalog: bool,
-) -> str:
-    """Closed-world ``assign_to`` resolution (fail-closed; roots graft-only).
+) -> Optional[str]:
+    """Closed-world ``parent`` resolution (fail-closed; structural roots barred).
 
-    Bracketed ``[t_xxxx]`` aliases resolve through the injected catalog;
-    bare tokens must be published uuids when a catalog is present. Anything
-    unresolvable -- and anything resolving to a protected realm root -- is
-    coerced to the literal ``NEW``. Without a catalog the contract rule
-    applies: bracketed aliases are unresolvable (coerce), bare tokens are
-    accepted as already-resolved uuids.
+    ``node`` / ``root`` -- the structural scaffolding above the domain roots --
+    are never valid parents, catalog or not: they coerce to None (the cascade
+    decides placement) with a logged warning. With a catalog present any other
+    parent must resolve (canonicalized) to a published name; unresolvable
+    parents likewise coerce to None (closed-world). Without a catalog
+    non-structural names pass through canonicalized -- placement validity is
+    then left to the cascade.
     """
-    if not isinstance(raw_assign, str):
-        return "NEW"
-    token = raw_assign.strip()
-    if not token or token == "NEW":
-        return "NEW"
-    if token.startswith("[") or token.endswith("]"):
-        alias = token.strip("[]").strip()
-        resolved = alias_to_uuid.get(alias)
-        if resolved is None:
-            logger.info(
-                "type_cluster: closed_world_coerce on unresolved alias %s",
-                token,
-            )
-            return "NEW"
-        if resolved in root_uuids:
-            logger.info("type_cluster: protected_root_coerce on assign_to %s", token)
-            return "NEW"
-        return resolved
-    if has_catalog:
-        if token not in published_uuids:
-            logger.info("type_cluster: closed_world_coerce on unknown uuid %s", token)
-            return "NEW"
-        if token in root_uuids:
-            logger.info("type_cluster: protected_root_coerce on assign_to %s", token)
-            return "NEW"
-        return token
-    return token
+    if not isinstance(raw_parent, str) or not raw_parent.strip():
+        return None
+    parent = canonicalize(raw_parent)
+    if not parent:
+        return None
+    if parent in _STRUCTURAL_ROOTS:
+        logger.warning("type_cluster: bad_root_coerce on parent %s", parent)
+        return None
+    if has_catalog and parent not in catalog_names:
+        logger.info("type_cluster: closed_world_coerce on parent %s", parent)
+        return None
+    return parent
 
 
 class TypeClusterMember(BaseModel):
@@ -1724,7 +1710,9 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
     ]
     members_block = "\n".join(member_lines)
 
-    catalog_block, _alias_unused, _pub_unused, _root_unused = _build_catalog_context()
+    catalog_block, _alias_unused, _pub_unused, catalog_names = (
+        _build_catalog_context()
+    )
 
     system_msg = (
         "You type a cluster of entities. You are given the cluster's members "
@@ -1785,12 +1773,10 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
     name = canonicalize(raw_name)
 
     # parent: null => reuse `name`; else the existing type to graft under.
-    # Canonicalize for the cascade's by_norm lookup; placement validity (does
-    # the parent actually exist?) is the cascade's call, not Hermes'.
-    raw_parent = data.get("parent")
-    parent: Optional[str] = None
-    if isinstance(raw_parent, str) and raw_parent.strip():
-        parent = canonicalize(raw_parent)
+    # Canonicalized, then resolved closed-world: `node`/`root` and (with a
+    # catalog) unpublished names coerce to None; remaining placement validity
+    # is left to the cascade.
+    parent = _resolve_parent(data.get("parent"), catalog_names, bool(catalog_block))
 
     # Map outlier NAMES back to input ids over the known member set: exact,
     # then case/space-normalized. Names the model invented (no member match)

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1685,296 +1685,125 @@ class TypeClusterRequest(BaseModel):
         return value
 
 
-class TypeGroup(BaseModel):
-    assign_to: str = Field(..., description="A published type uuid OR the literal NEW.")
-    name: str = Field(..., description="Canonical lowercase-singular hypernym.")
-    chain: List[str] = Field(
-        ...,
-        description=(
-            "IS_A chain SPECIFIC->GENERAL; chain[0]==name, " "chain[-1] a realm root."
-        ),
-    )
-    member_ids: List[str] = Field(default_factory=list)
-    confidence: float = 0.5
-    description: str = ""
-    over_specified: bool = False
-
-
 class TypeClusterResponse(BaseModel):
+    """As-designed contract (#127): Hermes NAMES the cluster and flags the
+    OUTLIERS. Placement (IS_A chain, reuse/mint, root) is the cascade's job,
+    not Hermes' -- the model only names and rejects."""
+
     request_id: Optional[str] = None
-    groups: List[TypeGroup] = Field(default_factory=list)
-    residual_ids: List[str] = Field(default_factory=list)
-    raw_partition_ok: bool = True
+    name: str = ""  # canonical hypernym for the whole cluster
+    over_specified: bool = False
+    residual_ids: List[str] = Field(default_factory=list)  # members that don't fit
+    raw_partition_ok: bool = True  # every returned outlier name resolved to a member
 
 
 @app.post("/type-cluster", response_model=TypeClusterResponse)
 async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
-    """Type the categories that bind a cluster (naming-driven typing v2).
+    """Name the category that binds a cluster; return the members that don't fit.
 
-    Sophia points (coarse cluster); Hermes asserts (per-subgroup hypernym +
-    IS_A chain to a realm root + reuse/mint decision). This handler owns the
-    contract and fail-closed server-side validation; the placement cascade
-    is simulated by the offline harness.
+    Naming-driven typing v2, as designed (#127): Sophia points (the coarse
+    cluster); Hermes NAMES it (one canonical hypernym) and flags the OUTLIERS
+    (members that don't belong under that name). Hermes does NOT partition into
+    subgroups, propose an IS_A chain, or decide reuse/mint -- the placement
+    cascade (the offline harness) asserts all of that FROM the name. The model
+    reasons over member NAMES and returns outlier NAMES; Hermes maps those back
+    to input ids over the known member set (the model never handles an id --
+    verbatim id echo was the source of the truncation/no-usable-groups
+    failures).
     """
     member_lines = []
     for mem in request.members:
-        line = f"- {mem.name} (id: {mem.id})"
+        line = f"- {mem.name}"
         if mem.hermes_type_hint:
             line += f" (hint: {mem.hermes_type_hint})"
         member_lines.append(line)
     members_block = "\n".join(member_lines)
 
-    (
-        catalog_block,
-        alias_to_uuid,
-        published_uuids,
-        root_uuids,
-    ) = _build_catalog_context()
-    # Part of the catalog snapshot: capture once here instead of
-    # re-reading the live _type_registry global per group below.
-    has_catalog = _type_registry is not None
-
     system_msg = (
-        "You are an ontology typing assistant. Partition the cluster members "
-        "into one or more semantic subgroups. For each subgroup return a "
-        "canonical hypernym `name` (lowercase singular noun), an IS_A `chain` "
-        "from specific to general ending in exactly one realm root "
-        "(entity, concept, or process), `member_ids` (the EXACT input ids in "
-        "that subgroup), and `assign_to` (the bracketed id of an existing "
-        'published type to reuse, or the literal "NEW" to mint). Cover '
-        "EVERY input id exactly once across the subgroups; ids that fit "
-        "nothing go in top-level `residual_ids`. Return ONLY a JSON object: "
-        '{"groups": [{"assign_to": "<id-or-NEW>", "name": "<noun>", '
-        '"chain": ["<specific>", ..., "<root>"], '
-        '"member_ids": ["<id>", ...], "confidence": <0.0-1.0>, '
-        '"description": "<short>"}], "residual_ids": ["<id>", ...]}.'
+        "You name the single category that binds a cluster of entities "
+        "together. Return a canonical hypernym `name` (a lowercase singular "
+        "noun) for the WHOLE cluster, and `outliers`: the EXACT names of any "
+        "listed members that do NOT belong under that category. Most clusters "
+        "have no outliers. Do not split the cluster or invent ids. Return ONLY "
+        'a JSON object: {"name": "<noun>", "outliers": ["<member name>", ...]}.'
     )
-    if catalog_block:
-        system_msg += "\n\n" + catalog_block
     user_msg = (
         "These entities were grouped together (embedding-coarse cluster):\n"
-        f"{members_block}\n\nType them."
+        f"{members_block}\n\nName the category that binds them, and list any "
+        "that do not fit."
     )
 
-    # Budget for what the response actually costs, not just member count
-    # (#126): member_ids are full UUIDs (~12 tokens each) and EVERY group
-    # carries name + assign_to + an IS_A chain (up to ~5 hops), so a small
-    # cluster that splits into many groups can blow a member-count-only
-    # budget and truncate into unparseable JSON (a hard 502 below).
-    max_tokens = min(6144, 1024 + 128 * len(request.members))
+    # Bounded response: one name + a short outlier list. The member-count
+    # token scaling that the partition contract needed (#126) is moot here.
     result = await generate_completion(
         messages=[
             {"role": "system", "content": system_msg},
             {"role": "user", "content": user_msg},
         ],
         temperature=0.0,
-        max_tokens=max_tokens,
+        max_tokens=512,
     )
     choices = result.get("choices", [])
     if not choices:
         raise HTTPException(status_code=502, detail="LLM returned no choices")
-
     content = choices[0]["message"]["content"]
-    # Truncation detection: a clipped member_ids tail makes the JSON
-    # unparseable. Surface it as a 502 (raw partition fidelity is gone)
-    # rather than letting a truncated tail masquerade as healthy residual
-    # backlog.
+
     try:
         data = _extract_json(content)
     except Exception:
-        logger.warning("type_cluster: truncated_response (unparseable JSON)")
+        logger.warning("type_cluster: unparseable JSON")
         raise HTTPException(
-            status_code=502,
-            detail="LLM typing response was truncated/unparseable",
+            status_code=502, detail="LLM typing response was unparseable"
         )
     if not isinstance(data, dict):
         raise HTTPException(
             status_code=502, detail="LLM typing response is not a JSON object"
         )
 
-    input_id_set = {mem.id for mem in request.members}
+    raw_name = data.get("name")
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        raise HTTPException(
+            status_code=502, detail="LLM typing response had no usable name"
+        )
+    over_specified = _is_over_specified(raw_name)
+    name = canonicalize(raw_name)
 
-    raw_groups = data.get("groups")
-    if not isinstance(raw_groups, list):
-        raw_groups = []
-    raw_residual = data.get("residual_ids")
-    if not isinstance(raw_residual, list):
-        raw_residual = []
+    # Map outlier NAMES back to input ids over the known member set: exact,
+    # then case/space-normalized. Names the model invented (no member match)
+    # are dropped -- they cannot designate a real node. Names, not ids,
+    # because the model reproduces the medium it reasoned over far more
+    # reliably than a 36-char uuid, and the candidate set is small + known
+    # (#127).
+    raw_outliers = data.get("outliers")
+    if not isinstance(raw_outliers, list):
+        raw_outliers = []
 
-    # --- raw-fidelity bookkeeping (on the LLM output BEFORE reconcile) ---
-    raw_claimed: list[str] = []
-    raw_partition_ok = True
-    for g in raw_groups:
-        if not isinstance(g, dict):
-            raw_partition_ok = False
-            continue
-        gids = g.get("member_ids")
-        if not isinstance(gids, list):
-            raw_partition_ok = False
-            continue
-        raw_claimed.extend([gid for gid in gids if isinstance(gid, str)])
-    # subset: every raw-claimed id is a real input id
-    if any(gid not in input_id_set for gid in raw_claimed):
-        raw_partition_ok = False
-    # disjoint: no id claimed by two groups
-    if len(raw_claimed) != len(set(raw_claimed)):
-        raw_partition_ok = False
-    # total: raw group ids + returned residual cover every input id
-    raw_residual_in = {
-        r for r in raw_residual if isinstance(r, str) and r in input_id_set
-    }
-    if set(raw_claimed) | raw_residual_in != input_id_set:
-        raw_partition_ok = False
+    def _norm(value: str) -> str:
+        return " ".join(str(value).strip().lower().split())
 
-    # --- reconciliation: first-claim wins, dedup, drop hallucinated ids ---
+    by_norm: dict[str, list[str]] = {}
+    for mem in request.members:
+        by_norm.setdefault(_norm(mem.name), []).append(mem.id)
+
     claimed: set[str] = set()
-    out_groups: list[TypeGroup] = []
-    for g in raw_groups:
-        if not isinstance(g, dict):
-            continue
-        raw_name = g.get("name")
-        if not isinstance(raw_name, str) or not raw_name.strip():
-            logger.warning("type_cluster: dropping group with missing name")
-            continue
-        gids_raw = g.get("member_ids")
-        if not isinstance(gids_raw, list):
-            gids_raw = []
-        kept_ids: list[str] = []
-        for gid in gids_raw:
-            if isinstance(gid, str) and gid in input_id_set and gid not in claimed:
-                claimed.add(gid)
-                kept_ids.append(gid)
-        if not kept_ids:
-            logger.warning(
-                "type_cluster: dropping group %s with no valid ids", raw_name
-            )
-            continue
+    residual_ids: list[str] = []
+    named_outliers = [o for o in raw_outliers if isinstance(o, str)]
+    for outlier in named_outliers:
+        for mid in by_norm.get(_norm(outlier), []):
+            if mid not in claimed:
+                claimed.add(mid)
+                residual_ids.append(mid)
+                break
 
-        # over_specified is computed on the RAW name, pre-canonicalize.
-        over_specified = _is_over_specified(raw_name)
-        canon_name = canonicalize(raw_name)
-
-        # chain validation: canonicalize each link; de-dup consecutive
-        # repeats; append a deterministic root if missing; force
-        # chain[0] == name; cap length keeping the root. Never reject a
-        # group on a bad chain.
-        raw_chain = g.get("chain")
-        if not isinstance(raw_chain, list):
-            raw_chain = []
-        chain: list[str] = []
-        for link in raw_chain:
-            if not isinstance(link, str) or not link.strip():
-                continue
-            canon_link = canonicalize(link)
-            if not chain or chain[-1] != canon_link:
-                chain.append(canon_link)
-        if not chain or chain[-1] not in _TYPE_ROOTS:
-            chain.append("entity")  # deterministic default realm root
-            logger.warning(
-                "type_cluster: bad_root -- appended default root for %s",
-                canon_name,
-            )
-        if chain[0] != canon_name:
-            if canon_name in chain:
-                # canon_name already appears deeper in the chain: slice
-                # from its first occurrence (dropping the more-specific
-                # prefix) so the SPEC 5.2 graft walk never sees a
-                # non-consecutive duplicate of the name.
-                chain = chain[chain.index(canon_name) :]
-            else:
-                chain = [canon_name] + chain
-        if len(chain) > _MAX_CHAIN:
-            chain = chain[: _MAX_CHAIN - 1] + [chain[-1]]
-
-        assign_to = _resolve_assign_to(
-            g.get("assign_to"),
-            alias_to_uuid,
-            published_uuids,
-            root_uuids,
-            has_catalog=has_catalog,
-        )
-
-        try:
-            confidence = float(g.get("confidence", 0.5))
-        except (TypeError, ValueError):
-            confidence = 0.5
-        confidence = max(0.0, min(1.0, confidence))
-
-        description = g.get("description", "")
-        if not isinstance(description, str):
-            description = ""
-
-        out_groups.append(
-            TypeGroup(
-                assign_to=assign_to,
-                name=canon_name,
-                chain=chain,
-                member_ids=kept_ids,
-                confidence=confidence,
-                description=description,
-                over_specified=over_specified,
-            )
-        )
-
-    if not out_groups:
-        raise HTTPException(
-            status_code=502,
-            detail="LLM typing response contained no usable groups",
-        )
-
-    # Intra-response canonical-name merge: groups are merged ONLY when the
-    # canonical name AND the proposed chain[-1] root both collide (union
-    # member_ids, keep the higher-confidence chain); different roots stay
-    # split (homonym guard).
-    merged: dict[tuple[str, str], TypeGroup] = {}
-    merged_order: list[tuple[str, str]] = []
-    for grp in out_groups:
-        key = (grp.name, grp.chain[-1])
-        existing = merged.get(key)
-        if existing is None:
-            merged[key] = grp
-            merged_order.append(key)
-            continue
-        winner = grp if grp.confidence > existing.confidence else existing
-        merged[key] = TypeGroup(
-            assign_to=winner.assign_to,
-            name=winner.name,
-            chain=list(winner.chain),
-            member_ids=existing.member_ids + grp.member_ids,
-            confidence=winner.confidence,
-            description=winner.description,
-            over_specified=existing.over_specified or grp.over_specified,
-        )
-        logger.info(
-            "type_cluster: merged duplicate canonical group %s (root %s)",
-            key[0],
-            key[1],
-        )
-    out_groups = [merged[k] for k in merged_order]
-
-    # residual = input ids never claimed by a kept group. Set-equivalent
-    # to the SPEC 3.4 union (input - claimed) | (raw_residual_in - claimed)
-    # because raw_residual_in is filtered to input_id_set above.
-    residual_ids = sorted(input_id_set - claimed)
-
-    # Final safety assert: groups disjoint-union residual == input ids
-    # (failure here is a server bug => 500).
-    final_union: set[str] = set()
-    for grp in out_groups:
-        final_union |= set(grp.member_ids)
-    if (
-        final_union & set(residual_ids)
-        or (final_union | set(residual_ids)) != input_id_set
-    ):
-        logger.error("type_cluster: post-reconcile partition broken")
-        raise HTTPException(
-            status_code=500, detail="typing partition invariant violated"
-        )
+    # raw fidelity: every outlier name the model returned resolved to a real
+    # member (no hallucinated outlier names).
+    raw_partition_ok = len(claimed) == len(named_outliers)
 
     return TypeClusterResponse(
         request_id=request.request_id,
-        groups=out_groups,
-        residual_ids=residual_ids,
+        name=name,
+        over_specified=over_specified,
+        residual_ids=sorted(residual_ids),
         raw_partition_ok=raw_partition_ok,
     )
 

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1506,9 +1506,12 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
 # v2 typing pass: POST /type-cluster (naming-driven typing experiment T4)
 #
 # Parallel to /name-cluster but catalog-aware: one LLM pass per cluster
-# emits a hypernym + IS_A chain to a realm root + reuse/mint decision per
-# subgroup. This module owns the contract + fail-closed server-side
-# validation only; the placement cascade lives in the offline harness.
+# emits {name, parent, outliers} -- it NAMES the cluster at the closest
+# covering hypernym, picks `parent` from the existing catalog (null =
+# reuse `name`), and lists outliers. No chain, no ids, no sub-partitioning
+# from the LLM: the placement cascade (sophia) PLACES the type and derives
+# any chain by walking the graph. This module owns the contract +
+# fail-closed server-side validation only.
 # The catalog is read from the module-level Redis-synced ``_type_registry``
 # (duck-typed: get_type_names() / get_type(name)); tests monkeypatch an
 # in-process stub (experiment path A).
@@ -1520,9 +1523,6 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
 # minted in the current design, so it is excluded from the catalog as well.
 _STRUCTURAL_ROOTS: set[str] = {"node", "root"}
 _CATALOG_EXCLUDED: set[str] = _STRUCTURAL_ROOTS | {"cognition"}
-
-# Hard ceiling on chain length (the root link is always kept).
-_MAX_CHAIN: int = 8
 
 # Over-specification ceiling (computed on the RAW name, pre-canonicalize).
 MAX_WORDS: int = 3
@@ -1592,7 +1592,6 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
                 "name": name,
                 "uuid": type_uuid,
                 "root": str(info.get("root") or ""),
-                "chain": info.get("chain"),
             }
         )
     entries.sort(key=lambda e: (e["root"], e["name"]))
@@ -1609,9 +1608,6 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
         entry_name = entry["name"]
         entry_root = entry["root"] or "?"
         line = f"  [{alias}] {entry_name} (root: {entry_root})"
-        chain = entry["chain"]
-        if isinstance(chain, list) and chain:
-            line += "  chain: " + " > ".join(str(c) for c in chain)
         lines.append(line)
     return "\n".join(lines), alias_to_uuid, published_uuids, catalog_names
 

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1686,12 +1686,18 @@ class TypeClusterRequest(BaseModel):
 
 
 class TypeClusterResponse(BaseModel):
-    """As-designed contract (#127): Hermes NAMES the cluster and flags the
-    OUTLIERS. Placement (IS_A chain, reuse/mint, root) is the cascade's job,
-    not Hermes' -- the model only names and rejects."""
+    """As-designed contract (#127): Hermes NAMES the cluster, picks an existing
+    PARENT when minting, and flags the OUTLIERS. The cascade asserts placement
+    (reuse / graft / root + the full IS_A chain) from the name + parent.
+
+    parent semantics: null  => `name` is an existing type to REUSE.
+                       set   => mint NEW `name` under this existing parent
+                                (which may be a domain root).
+    The model works in NAMES only -- never a chain, never an id."""
 
     request_id: Optional[str] = None
-    name: str = ""  # canonical hypernym for the whole cluster
+    name: str = ""  # canonical type name for the whole cluster
+    parent: Optional[str] = None  # existing parent to graft under; null => reuse
     over_specified: bool = False
     residual_ids: List[str] = Field(default_factory=list)  # members that don't fit
     raw_partition_ok: bool = True  # every returned outlier name resolved to a member
@@ -1699,42 +1705,51 @@ class TypeClusterResponse(BaseModel):
 
 @app.post("/type-cluster", response_model=TypeClusterResponse)
 async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
-    """Name the category that binds a cluster; return the members that don't fit.
+    """Name the category that binds a cluster; pick an existing parent or reuse.
 
     Naming-driven typing v2, as designed (#127): Sophia points (the coarse
-    cluster); Hermes NAMES it (one canonical hypernym) and flags the OUTLIERS
-    (members that don't belong under that name). Hermes does NOT partition into
-    subgroups, propose an IS_A chain, or decide reuse/mint -- the placement
-    cascade (the offline harness) asserts all of that FROM the name. The model
-    reasons over member NAMES and returns outlier NAMES; Hermes maps those back
-    to input ids over the known member set (the model never handles an id --
-    verbatim id echo was the source of the truncation/no-usable-groups
-    failures).
+    cluster); Hermes NAMES it and -- choosing FROM WHAT EXISTS -- either reuses
+    the most specific existing type that fits (parent=null) or mints a new
+    `name` under the most specific existing `parent` (which may be a domain
+    root; minting under a root is always legal). It also flags OUTLIERS:
+    members that don't belong. Hermes does NOT emit an IS_A chain, sub-partition
+    the cluster, or echo ids -- the placement cascade asserts the full chain
+    from the name + parent. The model reasons over member NAMES and existing
+    type NAMES, and returns NAMES; ids never reach it (verbatim id echo was the
+    source of the truncation / no-usable-groups failures).
     """
-    member_lines = []
-    for mem in request.members:
-        line = f"- {mem.name}"
-        if mem.hermes_type_hint:
-            line += f" (hint: {mem.hermes_type_hint})"
-        member_lines.append(line)
+    member_lines = [
+        f"- {mem.name}" + (f" (hint: {mem.hermes_type_hint})" if mem.hermes_type_hint else "")
+        for mem in request.members
+    ]
     members_block = "\n".join(member_lines)
 
+    catalog_block, _alias_unused, _pub_unused, _root_unused = _build_catalog_context()
+
     system_msg = (
-        "You name the single category that binds a cluster of entities "
-        "together. Return a canonical hypernym `name` (a lowercase singular "
-        "noun) for the WHOLE cluster, and `outliers`: the EXACT names of any "
-        "listed members that do NOT belong under that category. Most clusters "
-        "have no outliers. Do not split the cluster or invent ids. Return ONLY "
-        'a JSON object: {"name": "<noun>", "outliers": ["<member name>", ...]}.'
+        "You type a cluster of entities. You are given the cluster's members "
+        "and the existing type catalog. Choose FROM WHAT EXISTS: return the "
+        "most specific existing type that fits the WHOLE cluster as `name` "
+        "with `parent`: null (reuse it). If no existing type fits, mint a new "
+        "type: return the new `name` (a lowercase singular noun) and `parent` "
+        "= the most specific existing type to place it under (a domain root -- "
+        "entity, concept, or process -- is a valid parent). Also return "
+        "`outliers`: the EXACT names of any listed members that do not belong "
+        "under `name`. Do not invent ids or chains. Return ONLY a JSON object: "
+        '{"name": "<noun>", "parent": "<existing type>" or null, '
+        '"outliers": ["<member name>", ...]}.'
     )
+    if catalog_block:
+        system_msg += "\n\n" + catalog_block
     user_msg = (
         "These entities were grouped together (embedding-coarse cluster):\n"
-        f"{members_block}\n\nName the category that binds them, and list any "
-        "that do not fit."
+        f"{members_block}\n\nType them: name the category that binds them "
+        "(reuse an existing type if one fits, else mint under the most "
+        "specific existing parent), and list any members that do not fit."
     )
 
-    # Bounded response: one name + a short outlier list. The member-count
-    # token scaling that the partition contract needed (#126) is moot here.
+    # Bounded response: one name + one parent + a short outlier list. The
+    # per-member token scaling the partition contract needed (#126) is moot.
     result = await generate_completion(
         messages=[
             {"role": "system", "content": system_msg},
@@ -1768,12 +1783,18 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
     over_specified = _is_over_specified(raw_name)
     name = canonicalize(raw_name)
 
+    # parent: null => reuse `name`; else the existing type to graft under.
+    # Canonicalize for the cascade's by_norm lookup; placement validity (does
+    # the parent actually exist?) is the cascade's call, not Hermes'.
+    raw_parent = data.get("parent")
+    parent: Optional[str] = None
+    if isinstance(raw_parent, str) and raw_parent.strip():
+        parent = canonicalize(raw_parent)
+
     # Map outlier NAMES back to input ids over the known member set: exact,
     # then case/space-normalized. Names the model invented (no member match)
-    # are dropped -- they cannot designate a real node. Names, not ids,
-    # because the model reproduces the medium it reasoned over far more
-    # reliably than a 36-char uuid, and the candidate set is small + known
-    # (#127).
+    # are dropped. Names, not ids -- the model reproduces the medium it
+    # reasoned over far more reliably than a 36-char uuid (#127).
     raw_outliers = data.get("outliers")
     if not isinstance(raw_outliers, list):
         raw_outliers = []
@@ -1795,13 +1816,12 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
                 residual_ids.append(mid)
                 break
 
-    # raw fidelity: every outlier name the model returned resolved to a real
-    # member (no hallucinated outlier names).
     raw_partition_ok = len(claimed) == len(named_outliers)
 
     return TypeClusterResponse(
         request_id=request.request_id,
         name=name,
+        parent=parent,
         over_specified=over_specified,
         residual_ids=sorted(residual_ids),
         raw_partition_ok=raw_partition_ok,

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1757,6 +1757,7 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         ],
         temperature=0.0,
         max_tokens=512,
+        metadata={"request_id": request.request_id},
     )
     choices = result.get("choices", [])
     if not choices:

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1700,14 +1700,13 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
     source of the truncation / no-usable-groups failures).
     """
     member_lines = [
-        f"- {mem.name}" + (f" (hint: {mem.hermes_type_hint})" if mem.hermes_type_hint else "")
+        f"- {mem.name}"
+        + (f" (hint: {mem.hermes_type_hint})" if mem.hermes_type_hint else "")
         for mem in request.members
     ]
     members_block = "\n".join(member_lines)
 
-    catalog_block, _alias_unused, _pub_unused, catalog_names = (
-        _build_catalog_context()
-    )
+    catalog_block, _alias_unused, _pub_unused, catalog_names = _build_catalog_context()
 
     system_msg = (
         "You type a cluster of entities. You are given the cluster's members "

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1560,14 +1560,16 @@ def _is_over_specified(raw_name: str) -> bool:
 def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
     """Build the catalog system-prompt block + closed-world resolution maps.
 
-    Returns ``(catalog_block, alias_to_uuid, published_uuids, catalog_names)``.
-    Entries are sorted by (root, name) so the block is stable across requests
+    Returns ``(catalog_block, {}, published_uuids, catalog_names)`` -- the
+    second slot is a vestigial empty dict, kept only for return-arity
+    stability (resolution is names-only; there are no aliases). Entries are
+    sorted by (root, name) so the block is stable across requests
     (prompt-cache friendly). Every published type -- the domain roots
-    (entity/concept/process) included -- is an ordinary entry with a bracketed
-    short alias ``[t_xxxx]``, valid both as a `parent` choice and as an honest
-    `name` reuse. Only the structural scaffolding above the roots (``node``,
-    ``root``) and the unminted ``cognition`` are excluded. With no registry
-    installed everything is empty (catalog-agnostic mode).
+    (entity/concept/process) included -- is an ordinary entry, valid both as a
+    `parent` choice and as an honest `name` reuse. Only the structural
+    scaffolding above the roots (``node``, ``root``) and the unminted
+    ``cognition`` are excluded. With no registry installed everything is empty
+    (catalog-agnostic mode).
     """
     registry = _type_registry
     if registry is None:
@@ -1597,19 +1599,16 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
     entries.sort(key=lambda e: (e["root"], e["name"]))
     published_uuids = {e["uuid"] for e in entries}
     catalog_names = {canonicalize(str(e["name"])) for e in entries}
-    alias_to_uuid: dict[str, str] = {}
     lines = [
         "PUBLISHED TYPE CATALOG (the existing types: reuse one as `name`, "
         "or pick one as the `parent` of a new type):"
     ]
-    for idx, entry in enumerate(entries):
-        alias = f"t_{idx:04d}"
-        alias_to_uuid[alias] = entry["uuid"]
+    for entry in entries:
         entry_name = entry["name"]
         entry_root = entry["root"] or "?"
-        line = f"  [{alias}] {entry_name} (root: {entry_root})"
+        line = f"  - {entry_name} (root: {entry_root})"
         lines.append(line)
-    return "\n".join(lines), alias_to_uuid, published_uuids, catalog_names
+    return "\n".join(lines), {}, published_uuids, catalog_names
 
 
 def _resolve_parent(
@@ -1734,15 +1733,24 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
 
     # Bounded response: one name + one parent + a short outlier list. The
     # per-member token scaling the partition contract needed (#126) is moot.
-    result = await generate_completion(
-        messages=[
-            {"role": "system", "content": system_msg},
-            {"role": "user", "content": user_msg},
-        ],
-        temperature=0.0,
-        max_tokens=512,
-        metadata={"request_id": request.request_id},
-    )
+    try:
+        result = await generate_completion(
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "user", "content": user_msg},
+            ],
+            temperature=0.0,
+            max_tokens=512,
+            metadata={"request_id": request.request_id},
+        )
+    except LLMProviderNotConfiguredError as exc:
+        logger.error("type_cluster: LLM provider not configured: %s", exc)
+        raise HTTPException(
+            status_code=503, detail="LLM provider not configured"
+        ) from exc
+    except LLMProviderError as exc:
+        logger.error("type_cluster: LLM provider error: %s", exc)
+        raise HTTPException(status_code=502, detail="LLM provider error") from exc
     choices = result.get("choices", [])
     if not choices:
         raise HTTPException(status_code=502, detail="LLM returned no choices")
@@ -1767,6 +1775,11 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         )
     over_specified = _is_over_specified(raw_name)
     name = canonicalize(raw_name)
+    if not name:
+        raise HTTPException(
+            status_code=502,
+            detail="LLM returned an empty/uncanonicalizable cluster name",
+        )
 
     # parent: null => reuse `name`; else the existing type to graft under.
     # Canonicalized, then resolved closed-world: `node`/`root` and (with a

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1756,9 +1756,12 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         f"{members_block}\n\nType them."
     )
 
-    # max_tokens scales with member count so large clusters do not get the
-    # member_ids array clipped (truncation is a hard failure below).
-    max_tokens = min(4096, 512 + 24 * len(request.members))
+    # Budget for what the response actually costs, not just member count
+    # (#126): member_ids are full UUIDs (~12 tokens each) and EVERY group
+    # carries name + assign_to + an IS_A chain (up to ~5 hops), so a small
+    # cluster that splits into many groups can blow a member-count-only
+    # budget and truncate into unparseable JSON (a hard 502 below).
+    max_tokens = min(6144, 1024 + 128 * len(request.members))
     result = await generate_completion(
         messages=[
             {"role": "system", "content": system_msg},

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -19,7 +19,7 @@ client = TestClient(m.app)
 
 
 def _make_completion(content: str):
-    async def fake_completion(messages, temperature=0.0, max_tokens=512):
+    async def fake_completion(messages, temperature=0.0, max_tokens=512, **kwargs):
         # The pin must reach the wire, and the prompt must carry member NAMES.
         assert temperature == 0.0
         fake_completion.last_messages = messages  # type: ignore[attr-defined]
@@ -187,7 +187,7 @@ def test_blank_name_is_502(monkeypatch):
 
 
 def test_no_choices_is_502(monkeypatch):
-    async def empty(messages, temperature=0.0, max_tokens=512):
+    async def empty(messages, temperature=0.0, max_tokens=512, **kwargs):
         return {"choices": []}
 
     monkeypatch.setattr(m, "generate_completion", empty)

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -250,7 +250,11 @@ def test_parent_string_passes_through_canonicalized(monkeypatch):
         "generate_completion",
         _make_completion(json.dumps({"name": "sedan", "parent": "Vehicles"})),
     )
-    body = _post(_members(("i1", "a sedan"),)).json()
+    body = _post(
+        _members(
+            ("i1", "a sedan"),
+        )
+    ).json()
     assert body["name"] == "sedan"
     assert body["parent"] == "vehicle"  # canonicalized existing-parent name
 
@@ -259,7 +263,11 @@ def test_missing_parent_key_is_reuse(monkeypatch):
     monkeypatch.setattr(
         m, "generate_completion", _make_completion(json.dumps({"name": "star"}))
     )
-    body = _post(_members(("i1", "vega"),)).json()
+    body = _post(
+        _members(
+            ("i1", "vega"),
+        )
+    ).json()
     assert body["parent"] is None
 
 

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -201,7 +201,9 @@ def test_empty_members_rejected_by_contract():
 
 # --------------------------------------------------------------------------
 # parent: null => reuse `name`; a string => mint `name` under that existing
-# type. Passed through canonicalized; placement validity is the cascade's job.
+# type. Canonicalized, then resolved closed-world: structural roots
+# (`node`/`root`) and -- with a catalog -- unpublished names coerce to None;
+# remaining placement validity is left to the cascade.
 # --------------------------------------------------------------------------
 
 
@@ -232,4 +234,135 @@ def test_missing_parent_key_is_reuse(monkeypatch):
         m, "generate_completion", _make_completion(json.dumps({"name": "star"}))
     )
     body = _post(_members(("i1", "vega"),)).json()
+    assert body["parent"] is None
+
+
+# --------------------------------------------------------------------------
+# Catalog construction: domain roots (entity/concept/process) are ordinary
+# catalog citizens -- aliased like every published type, valid both as a
+# `parent` and as an honest `name` reuse. Only the structural scaffolding
+# above them (`node`, `root`) and the unminted `cognition` are excluded.
+# --------------------------------------------------------------------------
+
+
+_CATALOG_TYPES = {
+    "entity": {"uuid": "u-entity", "root": "entity", "chain": []},
+    "concept": {"uuid": "u-concept", "root": "concept", "chain": []},
+    "process": {"uuid": "u-process", "root": "process", "chain": []},
+    "vehicle": {"uuid": "u-vehicle", "root": "entity", "chain": ["entity"]},
+    # Structural / unminted: must never reach the catalog.
+    "node": {"uuid": "u-node", "root": "", "chain": []},
+    "root": {"uuid": "u-root", "root": "", "chain": []},
+    "cognition": {"uuid": "u-cognition", "root": "", "chain": []},
+}
+
+
+class _FakeRegistry:
+    def get_type_names(self):
+        return list(_CATALOG_TYPES)
+
+    def get_type(self, name):
+        return dict(_CATALOG_TYPES[name])
+
+
+def test_domain_roots_are_ordinary_catalog_entries(monkeypatch):
+    monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
+    block, alias_to_uuid, _published, catalog_names = m._build_catalog_context()
+    entry_lines = [ln for ln in block.splitlines() if ln.lstrip().startswith("[t_")]
+    for root in ("entity", "concept", "process"):
+        assert any(f"] {root} (" in ln for ln in entry_lines)  # aliased entry
+        assert root in catalog_names
+    assert {"u-entity", "u-concept", "u-process"} <= set(alias_to_uuid.values())
+    assert "GRAFT-ONLY" not in block  # no special-casing block anywhere
+
+
+def test_catalog_never_lists_node_root_or_cognition(monkeypatch):
+    monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
+    _block, alias_to_uuid, published, catalog_names = m._build_catalog_context()
+    assert {"node", "root", "cognition"}.isdisjoint(catalog_names)
+    assert {"u-node", "u-root", "u-cognition"}.isdisjoint(published)
+    assert {"u-node", "u-root", "u-cognition"}.isdisjoint(set(alias_to_uuid.values()))
+
+
+def test_prompt_lists_roots_without_graft_only_block(monkeypatch):
+    monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
+    fake = _make_completion(json.dumps({"name": "vehicle"}))
+    monkeypatch.setattr(m, "generate_completion", fake)
+    _post(_members(("i1", "boat")))
+    system_prompt = fake.last_messages[0]["content"]
+    assert "GRAFT-ONLY" not in system_prompt
+    assert "] entity (" in system_prompt  # roots listed as ordinary entries
+
+
+# --------------------------------------------------------------------------
+# parent resolution is fail-closed: `node`/`root` (structural, never in the
+# catalog) coerce to None with a logged warning; with a catalog present, a
+# parent that does not resolve to a published name coerces too (closed-world).
+# --------------------------------------------------------------------------
+
+
+def _spy_warnings(monkeypatch):
+    logged: list[str] = []
+    monkeypatch.setattr(
+        m.logger, "warning", lambda msg, *args, **kw: logged.append(msg % args)
+    )
+    return logged
+
+
+def test_parent_node_is_coerced_and_logged(monkeypatch):
+    logged = _spy_warnings(monkeypatch)
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "sensor", "parent": "node"})),
+    )
+    body = _post(_members(("i1", "lidar"))).json()
+    assert body["parent"] is None  # structural root never passes through
+    assert any("bad_root_coerce" in entry for entry in logged)
+
+
+def test_parent_root_is_coerced_and_logged(monkeypatch):
+    logged = _spy_warnings(monkeypatch)
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "sensor", "parent": "Root"})),
+    )
+    body = _post(_members(("i1", "lidar"))).json()
+    assert body["parent"] is None
+    assert any("bad_root_coerce" in entry for entry in logged)
+
+
+def test_unresolvable_parent_is_coerced_when_catalog_present(monkeypatch):
+    monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "sedan", "parent": "starship"})),
+    )
+    body = _post(_members(("i1", "a sedan"))).json()
+    assert body["name"] == "sedan"
+    assert body["parent"] is None  # closed-world: not a published name
+
+
+def test_domain_root_is_a_valid_parent(monkeypatch):
+    monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "sedan", "parent": "Entity"})),
+    )
+    body = _post(_members(("i1", "a sedan"))).json()
+    assert body["parent"] == "entity"  # ordinary catalog citizen
+
+
+def test_domain_root_is_a_valid_name_reuse(monkeypatch):
+    monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "process", "parent": None})),
+    )
+    body = _post(_members(("i1", "fermentation"))).json()
+    assert body["name"] == "process"
     assert body["parent"] is None

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -194,6 +194,32 @@ def test_no_choices_is_502(monkeypatch):
     assert _post(_members(("i1", "x"))).status_code == 502
 
 
+def test_empty_canonical_name_is_502(monkeypatch):
+    # A name that survives .strip() truthiness but canonicalizes to empty must
+    # not slip through as a silent 200 with name="" (review #128).
+    monkeypatch.setattr(
+        m, "generate_completion", _make_completion(json.dumps({"name": "the"}))
+    )
+    monkeypatch.setattr(m, "canonicalize", lambda value: "")
+    assert _post(_members(("i1", "x"))).status_code == 502
+
+
+def test_provider_not_configured_is_503(monkeypatch):
+    async def boom(messages, temperature=0.0, max_tokens=512, **kwargs):
+        raise m.LLMProviderNotConfiguredError("no provider")
+
+    monkeypatch.setattr(m, "generate_completion", boom)
+    assert _post(_members(("i1", "x"))).status_code == 503
+
+
+def test_provider_error_is_502(monkeypatch):
+    async def boom(messages, temperature=0.0, max_tokens=512, **kwargs):
+        raise m.LLMProviderError("upstream down")
+
+    monkeypatch.setattr(m, "generate_completion", boom)
+    assert _post(_members(("i1", "x"))).status_code == 502
+
+
 def test_empty_members_rejected_by_contract():
     # min_length=1 on the request model: an empty cluster is a 422, not a call.
     assert client.post("/type-cluster", json={"members": []}).status_code == 422
@@ -239,8 +265,8 @@ def test_missing_parent_key_is_reuse(monkeypatch):
 
 # --------------------------------------------------------------------------
 # Catalog construction: domain roots (entity/concept/process) are ordinary
-# catalog citizens -- aliased like every published type, valid both as a
-# `parent` and as an honest `name` reuse. Only the structural scaffolding
+# catalog citizens -- plain name entries like every published type, valid both
+# as a `parent` and as an honest `name` reuse. Only the structural scaffolding
 # above them (`node`, `root`) and the unminted `cognition` are excluded.
 # --------------------------------------------------------------------------
 
@@ -267,21 +293,20 @@ class _FakeRegistry:
 
 def test_domain_roots_are_ordinary_catalog_entries(monkeypatch):
     monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
-    block, alias_to_uuid, _published, catalog_names = m._build_catalog_context()
-    entry_lines = [ln for ln in block.splitlines() if ln.lstrip().startswith("[t_")]
+    block, _alias, published, catalog_names = m._build_catalog_context()
+    entry_lines = [ln for ln in block.splitlines() if ln.lstrip().startswith("- ")]
     for root in ("entity", "concept", "process"):
-        assert any(f"] {root} (" in ln for ln in entry_lines)  # aliased entry
+        assert any(f"  - {root} (" in ln for ln in entry_lines)  # plain entry
         assert root in catalog_names
-    assert {"u-entity", "u-concept", "u-process"} <= set(alias_to_uuid.values())
+    assert {"u-entity", "u-concept", "u-process"} <= published
     assert "GRAFT-ONLY" not in block  # no special-casing block anywhere
 
 
 def test_catalog_never_lists_node_root_or_cognition(monkeypatch):
     monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
-    _block, alias_to_uuid, published, catalog_names = m._build_catalog_context()
+    _block, _alias, published, catalog_names = m._build_catalog_context()
     assert {"node", "root", "cognition"}.isdisjoint(catalog_names)
     assert {"u-node", "u-root", "u-cognition"}.isdisjoint(published)
-    assert {"u-node", "u-root", "u-cognition"}.isdisjoint(set(alias_to_uuid.values()))
 
 
 def test_prompt_lists_roots_without_graft_only_block(monkeypatch):
@@ -291,7 +316,7 @@ def test_prompt_lists_roots_without_graft_only_block(monkeypatch):
     _post(_members(("i1", "boat")))
     system_prompt = fake.last_messages[0]["content"]
     assert "GRAFT-ONLY" not in system_prompt
-    assert "] entity (" in system_prompt  # roots listed as ordinary entries
+    assert "  - entity (" in system_prompt  # roots listed as ordinary entries
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -246,14 +246,14 @@ def test_missing_parent_key_is_reuse(monkeypatch):
 
 
 _CATALOG_TYPES = {
-    "entity": {"uuid": "u-entity", "root": "entity", "chain": []},
-    "concept": {"uuid": "u-concept", "root": "concept", "chain": []},
-    "process": {"uuid": "u-process", "root": "process", "chain": []},
-    "vehicle": {"uuid": "u-vehicle", "root": "entity", "chain": ["entity"]},
+    "entity": {"uuid": "u-entity", "root": "entity"},
+    "concept": {"uuid": "u-concept", "root": "concept"},
+    "process": {"uuid": "u-process", "root": "process"},
+    "vehicle": {"uuid": "u-vehicle", "root": "entity"},
     # Structural / unminted: must never reach the catalog.
-    "node": {"uuid": "u-node", "root": "", "chain": []},
-    "root": {"uuid": "u-root", "root": "", "chain": []},
-    "cognition": {"uuid": "u-cognition", "root": "", "chain": []},
+    "node": {"uuid": "u-node", "root": ""},
+    "root": {"uuid": "u-root", "root": ""},
+    "cognition": {"uuid": "u-cognition", "root": ""},
 }
 
 

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -1,491 +1,199 @@
-"""Tests for the v2 /type-cluster endpoint (naming-driven typing experiment T4).
+"""Tests for the v2 /type-cluster endpoint -- as-designed contract (#127).
 
-Every test monkeypatches generate_completion -- no live LLM calls. The endpoint
-contract and server-side validation are exercised in isolation; where a test
-needs a catalog it injects an in-process stub TypeRegistry (experiment path A).
-The placement cascade lives in later tasks.
+Hermes NAMES the cluster and flags the OUTLIERS; it does NOT partition into
+subgroups, propose an IS_A chain, or decide reuse/mint (the placement cascade
+does all of that from the name). The model reasons over member NAMES and
+returns outlier NAMES; Hermes maps those back to input ids over the known
+member set -- the model never handles an id. Every test monkeypatches
+generate_completion; no live LLM calls.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any
 
 import hermes.main as m
 from fastapi.testclient import TestClient
 
+client = TestClient(m.app)
+
 
 def _make_completion(content: str):
-    """Build a fake generate_completion returning *content* as the LLM message."""
-
     async def fake_completion(messages, temperature=0.0, max_tokens=512):
+        # The pin must reach the wire, and the prompt must carry member NAMES.
+        assert temperature == 0.0
+        fake_completion.last_messages = messages  # type: ignore[attr-defined]
         return {"choices": [{"message": {"content": content}}]}
 
     return fake_completion
 
 
-class _StubTypeRegistry:
-    """Minimal in-process TypeRegistry stub (experiment path A)."""
-
-    def __init__(self, types: dict[str, dict[str, Any]]) -> None:
-        self._types = types
-
-    def get_type_names(self) -> list[str]:
-        return sorted(self._types)
-
-    def get_type(self, name: str) -> dict[str, Any] | None:
-        info = self._types.get(name)
-        return dict(info) if info is not None else None
+def _members(*pairs):
+    return [{"id": i, "name": n} for i, n in pairs]
 
 
-def test_type_cluster_happy_path_partitions_ids(monkeypatch):
-    """A well-formed two-group response round-trips, partitions all ids, and is clean."""
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "NEW",
-                    "name": "Vehicles",
-                    "chain": ["Vehicle", "Entity"],
-                    "member_ids": ["i1", "i2"],
-                    "confidence": 0.9,
-                    "description": "wheeled",
-                },
-                {
-                    "assign_to": "NEW",
-                    "name": "Mammal",
-                    "chain": ["mammal", "animal", "entity"],
-                    "member_ids": ["i3"],
-                },
-            ],
-            "residual_ids": [],
-        }
+def _post(members, request_id="t::0"):
+    return client.post(
+        "/type-cluster", json={"members": members, "request_id": request_id}
     )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post(
-        "/type-cluster",
-        json={
-            "members": [
-                {"id": "i1", "name": "car"},
-                {"id": "i2", "name": "truck"},
-                {"id": "i3", "name": "dog"},
-            ],
-            "request_id": "req-1",
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["request_id"] == "req-1"
-    assert body["raw_partition_ok"] is True
-    assert body["residual_ids"] == []
-    groups = body["groups"]
-    assert len(groups) == 2
-    # name + chain entries are canonicalized (lowercase singular); chain[0]==name.
-    g0 = groups[0]
-    assert g0["name"] == "vehicle"
-    assert g0["chain"][0] == "vehicle"
-    assert g0["chain"][-1] == "entity"
-    assert g0["member_ids"] == ["i1", "i2"]
-    assert g0["over_specified"] is False
-    # total partition: every input id is claimed exactly once across groups+residual.
-    claimed = [mid for g in groups for mid in g["member_ids"]] + body["residual_ids"]
-    assert sorted(claimed) == ["i1", "i2", "i3"]
 
 
-def test_type_cluster_empty_members_is_422():
-    """An empty cluster is a request-validation 422, not a fabricated typing."""
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": []})
-    assert resp.status_code == 422, resp.text
+# --------------------------------------------------------------------------
+# Naming
+# --------------------------------------------------------------------------
 
 
-def test_type_cluster_non_dict_llm_is_502(monkeypatch):
-    """A non-object JSON payload from the LLM surfaces as a 502 (bad upstream shape)."""
+def test_names_the_cluster_and_canonicalizes(monkeypatch):
     monkeypatch.setattr(
-        m, "generate_completion", _make_completion(json.dumps(["not", "a", "dict"]))
+        m, "generate_completion", _make_completion(json.dumps({"name": "Vehicles"}))
     )
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "x"}]})
-    assert resp.status_code == 502, resp.text
-
-
-def test_type_cluster_truncated_member_ids_is_502(monkeypatch):
-    """A clipped member_ids array (truncated tail) => raw_partition_ok False => 502."""
-    # Clip the closing brackets so the first-{/last-} fallback of _extract_json
-    # also fails (no closing brace remains anywhere in the payload).
-    full = json.dumps({"groups": [{"name": "vehicle", "member_ids": ["i1", "i2"]}]})
-    truncated = full[:-4]
-    monkeypatch.setattr(m, "generate_completion", _make_completion(truncated))
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "x"}]})
-    assert resp.status_code == 502, resp.text
-
-
-def test_type_cluster_unclaimed_ids_become_residual_and_flag_raw(monkeypatch):
-    """Ids the LLM omits land in residual_ids; raw_partition_ok is False (not total)."""
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "NEW",
-                    "name": "vehicle",
-                    "chain": ["vehicle", "entity"],
-                    "member_ids": ["i1"],
-                }
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post(
-        "/type-cluster",
-        json={"members": [{"id": "i1", "name": "car"}, {"id": "i2", "name": "truck"}]},
-    )
-    assert resp.status_code == 200, resp.text
+    resp = _post(_members(("i1", "boat"), ("i2", "car")))
+    assert resp.status_code == 200
     body = resp.json()
-    assert body["residual_ids"] == ["i2"]
-    assert body["raw_partition_ok"] is False
+    assert body["name"] == "vehicle"  # canonicalized lowercase singular
+    assert body["residual_ids"] == []
+    assert body["raw_partition_ok"] is True
+    assert body["request_id"] == "t::0"
 
 
-def test_type_cluster_hallucinated_and_duplicate_ids_dropped(monkeypatch):
-    """Unknown ids are dropped; a re-claimed id goes to its first group (first-claim wins)."""
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "NEW",
-                    "name": "vehicle",
-                    "chain": ["vehicle", "entity"],
-                    "member_ids": ["i1", "i1", "ghost"],
-                },
-                {
-                    "assign_to": "NEW",
-                    "name": "animal",
-                    "chain": ["animal", "entity"],
-                    "member_ids": ["i1", "i2"],
-                },
-            ],
-            "residual_ids": [],
-        }
+def test_no_outliers_key_means_no_residuals(monkeypatch):
+    monkeypatch.setattr(
+        m, "generate_completion", _make_completion(json.dumps({"name": "mammal"}))
     )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post(
-        "/type-cluster",
-        json={"members": [{"id": "i1", "name": "car"}, {"id": "i2", "name": "dog"}]},
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    groups = body["groups"]
-    assert groups[0]["member_ids"] == ["i1"]  # dedup + first-claim, ghost dropped
-    assert groups[1]["member_ids"] == ["i2"]  # i1 already claimed by group 0
-    assert body["raw_partition_ok"] is False  # raw output was not disjoint
-
-
-def test_type_cluster_chain_root_appended_when_missing(monkeypatch):
-    """A chain not terminating in a realm root gets a deterministic root appended."""
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "NEW",
-                    "name": "sedan",
-                    "chain": ["sedan", "vehicle"],
-                    "member_ids": ["i1"],
-                }
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
-    assert resp.status_code == 200, resp.text
-    chain = resp.json()["groups"][0]["chain"]
-    assert chain[0] == "sedan"
-    assert chain[-1] in {"entity", "concept", "process"}
-
-
-def test_type_cluster_chain_sliced_from_existing_name_occurrence(monkeypatch):
-    """A canon name already mid-chain slices the chain from that occurrence.
-
-    Naive prepend would mint a non-consecutive duplicate
-    (vehicle > car > vehicle > ...); slicing drops the more-specific
-    prefix and keeps the general tail intact.
-    """
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "NEW",
-                    "name": "vehicle",
-                    "chain": ["car", "vehicle", "machine", "entity"],
-                    "member_ids": ["i1"],
-                }
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
-    assert resp.status_code == 200, resp.text
-    chain = resp.json()["groups"][0]["chain"]
-    assert chain == ["vehicle", "machine", "entity"]
-
-
-def test_type_cluster_over_specified_flag(monkeypatch):
-    """A conjunction / too-many-words RAW name sets over_specified on the group."""
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "NEW",
-                    "name": "cars and trucks",
-                    "chain": ["vehicle", "entity"],
-                    "member_ids": ["i1"],
-                }
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["groups"][0]["over_specified"] is True
-
-
-def test_type_cluster_all_groups_invalid_is_502(monkeypatch):
-    """Every group missing name/member_ids => nothing usable => 502."""
-    content = json.dumps(
-        {"groups": [{"name": "", "member_ids": []}], "residual_ids": []}
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "x"}]})
-    assert resp.status_code == 502, resp.text
-
-
-def test_type_cluster_assign_to_unresolvable_coerced_new(monkeypatch):
-    """A bracketed alias that does not resolve against the catalog coerces to NEW."""
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "[nope-uuid]",
-                    "name": "vehicle",
-                    "chain": ["vehicle", "entity"],
-                    "member_ids": ["i1"],
-                }
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["groups"][0]["assign_to"] == "NEW"
-
-
-def test_canonicalize_name_lowercases_and_singularizes():
-    """The shared canonicalize impl is idempotent and collapses vehicle/vehicles."""
-    assert m.canonicalize("Vehicles") == "vehicle"
-    assert m.canonicalize("vehicle") == "vehicle"
-    assert m.canonicalize(m.canonicalize("Vehicles")) == "vehicle"
-    assert m.canonicalize("process") == "process"
-
-
-def test_type_cluster_duplicate_member_ids_is_422():
-    """Duplicate member ids break the total-partition contract => 422."""
-    client = TestClient(m.app)
-    resp = client.post(
-        "/type-cluster",
-        json={
-            "members": [
-                {"id": "i1", "name": "car"},
-                {"id": "i1", "name": "truck"},
-            ]
-        },
-    )
-    assert resp.status_code == 422, resp.text
-
-
-def test_type_cluster_alias_assign_resolves_against_stub_catalog(monkeypatch):
-    """A bracketed [t_xxxx] alias resolves to the published uuid it aliases."""
-    stub = _StubTypeRegistry(
-        {
-            "vehicle": {
-                "uuid": "type_vehicle_aaaa1111",
-                "root": "entity",
-                "chain": ["vehicle", "entity"],
-            }
-        }
-    )
-    monkeypatch.setattr(m, "_type_registry", stub)
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "[t_0000]",
-                    "name": "vehicle",
-                    "chain": ["vehicle", "entity"],
-                    "member_ids": ["i1"],
-                }
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["groups"][0]["assign_to"] == "type_vehicle_aaaa1111"
-
-
-def test_type_cluster_protected_root_assign_coerced_new(monkeypatch):
-    """assign_to resolving to a realm root uuid coerces to NEW (graft-only roots)."""
-    stub = _StubTypeRegistry(
-        {
-            "entity": {"uuid": "type_entity_root0001", "is_root": True},
-            "vehicle": {"uuid": "type_vehicle_aaaa1111", "root": "entity"},
-        }
-    )
-    monkeypatch.setattr(m, "_type_registry", stub)
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "type_entity_root0001",
-                    "name": "vehicle",
-                    "chain": ["vehicle", "entity"],
-                    "member_ids": ["i1"],
-                }
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["groups"][0]["assign_to"] == "NEW"
-
-
-def test_type_cluster_homonym_groups_not_merged(monkeypatch):
-    """Same canonical name under DIFFERENT proposed roots stays two groups."""
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "NEW",
-                    "name": "bank",
-                    "chain": ["bank", "entity"],
-                    "member_ids": ["i1"],
-                },
-                {
-                    "assign_to": "NEW",
-                    "name": "bank",
-                    "chain": ["bank", "concept"],
-                    "member_ids": ["i2"],
-                },
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post(
-        "/type-cluster",
-        json={
-            "members": [
-                {"id": "i1", "name": "river bank"},
-                {"id": "i2", "name": "trust"},
-            ]
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    groups = resp.json()["groups"]
-    assert len(groups) == 2
-    assert {g["chain"][-1] for g in groups} == {"entity", "concept"}
-
-
-def test_type_cluster_same_name_same_root_groups_merged(monkeypatch):
-    """Same canonical name AND same proposed root merge: union ids, best chain."""
-    content = json.dumps(
-        {
-            "groups": [
-                {
-                    "assign_to": "NEW",
-                    "name": "vehicle",
-                    "chain": ["vehicle", "entity"],
-                    "member_ids": ["i1"],
-                    "confidence": 0.6,
-                },
-                {
-                    "assign_to": "NEW",
-                    "name": "Vehicles",
-                    "chain": ["vehicle", "conveyance", "entity"],
-                    "member_ids": ["i2"],
-                    "confidence": 0.9,
-                },
-            ],
-            "residual_ids": [],
-        }
-    )
-    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
-    client = TestClient(m.app)
-    resp = client.post(
-        "/type-cluster",
-        json={"members": [{"id": "i1", "name": "car"}, {"id": "i2", "name": "truck"}]},
-    )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    groups = body["groups"]
-    assert len(groups) == 1
-    assert groups[0]["member_ids"] == ["i1", "i2"]
-    assert groups[0]["confidence"] == 0.9
-    assert groups[0]["chain"] == ["vehicle", "conveyance", "entity"]
+    body = _post(_members(("i1", "cat"), ("i2", "dog"))).json()
     assert body["residual_ids"] == []
     assert body["raw_partition_ok"] is True
 
 
-def test_type_cluster_catalog_block_in_system_prompt(monkeypatch):
-    """The catalog block (aliases + GRAFT-ONLY roots) lands in the SYSTEM prompt."""
-    stub = _StubTypeRegistry(
-        {"vehicle": {"uuid": "type_vehicle_aaaa1111", "root": "entity"}}
+# --------------------------------------------------------------------------
+# Outlier name -> id mapping (the model never echoes ids, #127)
+# --------------------------------------------------------------------------
+
+
+def test_outlier_name_maps_to_member_id(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "carbon", "outliers": ["diamond ring"]})),
     )
-    monkeypatch.setattr(m, "_type_registry", stub)
-    captured: dict[str, Any] = {}
+    body = _post(
+        _members(("u-graphite", "graphite"), ("u-ring", "diamond ring"))
+    ).json()
+    assert body["residual_ids"] == ["u-ring"]
+    assert body["raw_partition_ok"] is True
 
-    async def fake_completion(messages, temperature=0.0, max_tokens=512):
-        captured["messages"] = messages
-        captured["temperature"] = temperature
-        content = json.dumps(
-            {
-                "groups": [
-                    {
-                        "assign_to": "NEW",
-                        "name": "vehicle",
-                        "chain": ["vehicle", "entity"],
-                        "member_ids": ["i1"],
-                    }
-                ],
-                "residual_ids": [],
-            }
-        )
-        return {"choices": [{"message": {"content": content}}]}
 
-    monkeypatch.setattr(m, "generate_completion", fake_completion)
-    client = TestClient(m.app)
-    resp = client.post("/type-cluster", json={"members": [{"id": "i1", "name": "car"}]})
-    assert resp.status_code == 200, resp.text
-    system = captured["messages"][0]
-    assert system["role"] == "system"
-    assert "PUBLISHED TYPE CATALOG" in system["content"]
-    assert "[t_0000] vehicle" in system["content"]
-    assert "GRAFT-ONLY ROOTS" in system["content"]
-    assert captured["temperature"] == 0.0
+def test_outlier_match_is_case_and_space_normalized(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "star", "outliers": ["  THE   Sun "]})),
+    )
+    body = _post(_members(("u-vega", "vega"), ("u-sun", "the sun"))).json()
+    assert body["residual_ids"] == ["u-sun"]
+    assert body["raw_partition_ok"] is True
+
+
+def test_hallucinated_outlier_name_is_dropped_and_flags_raw_partition(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(
+            json.dumps({"name": "star", "outliers": ["a name not in the cluster"]})
+        ),
+    )
+    body = _post(_members(("u-vega", "vega"), ("u-sun", "the sun"))).json()
+    assert body["residual_ids"] == []  # unmatched outlier dropped
+    assert body["raw_partition_ok"] is False  # but the miss is surfaced
+
+
+def test_duplicate_member_name_claims_one_unclaimed_id(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "metal", "outliers": ["mercury"]})),
+    )
+    body = _post(
+        _members(("u-m1", "mercury"), ("u-m2", "mercury"), ("u-iron", "iron"))
+    ).json()
+    assert len(body["residual_ids"]) == 1
+    assert body["residual_ids"][0] in {"u-m1", "u-m2"}
+
+
+# --------------------------------------------------------------------------
+# over_specified ceiling signal (computed on the raw name)
+# --------------------------------------------------------------------------
+
+
+def test_over_specified_name_is_flagged(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "carbon and its allotropes"})),
+    )
+    body = _post(_members(("i1", "graphite"))).json()
+    assert body["over_specified"] is True
+
+
+def test_clean_name_not_over_specified(monkeypatch):
+    monkeypatch.setattr(
+        m, "generate_completion", _make_completion(json.dumps({"name": "carbon"}))
+    )
+    body = _post(_members(("i1", "graphite"))).json()
+    assert body["over_specified"] is False
+
+
+# --------------------------------------------------------------------------
+# The model is never asked to handle ids (the #127 contract guarantee)
+# --------------------------------------------------------------------------
+
+
+def test_prompt_carries_names_not_ids(monkeypatch):
+    fake = _make_completion(json.dumps({"name": "vehicle"}))
+    monkeypatch.setattr(m, "generate_completion", fake)
+    _post(_members(("uuid-aaaaaaaa", "boat"), ("uuid-bbbbbbbb", "car")))
+    prompt = " ".join(msg["content"] for msg in fake.last_messages)
+    assert "boat" in prompt and "car" in prompt
+    assert "uuid-aaaaaaaa" not in prompt and "uuid-bbbbbbbb" not in prompt
+
+
+# --------------------------------------------------------------------------
+# Fail-closed paths -> 502
+# --------------------------------------------------------------------------
+
+
+def test_unparseable_json_is_502(monkeypatch):
+    monkeypatch.setattr(m, "generate_completion", _make_completion("not json {{"))
+    assert _post(_members(("i1", "x"))).status_code == 502
+
+
+def test_non_object_json_is_502(monkeypatch):
+    monkeypatch.setattr(m, "generate_completion", _make_completion(json.dumps([1, 2])))
+    assert _post(_members(("i1", "x"))).status_code == 502
+
+
+def test_missing_name_is_502(monkeypatch):
+    monkeypatch.setattr(
+        m, "generate_completion", _make_completion(json.dumps({"outliers": []}))
+    )
+    assert _post(_members(("i1", "x"))).status_code == 502
+
+
+def test_blank_name_is_502(monkeypatch):
+    monkeypatch.setattr(
+        m, "generate_completion", _make_completion(json.dumps({"name": "   "}))
+    )
+    assert _post(_members(("i1", "x"))).status_code == 502
+
+
+def test_no_choices_is_502(monkeypatch):
+    async def empty(messages, temperature=0.0, max_tokens=512):
+        return {"choices": []}
+
+    monkeypatch.setattr(m, "generate_completion", empty)
+    assert _post(_members(("i1", "x"))).status_code == 502
+
+
+def test_empty_members_rejected_by_contract():
+    # min_length=1 on the request model: an empty cluster is a 422, not a call.
+    assert client.post("/type-cluster", json={"members": []}).status_code == 422

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -197,3 +197,39 @@ def test_no_choices_is_502(monkeypatch):
 def test_empty_members_rejected_by_contract():
     # min_length=1 on the request model: an empty cluster is a 422, not a call.
     assert client.post("/type-cluster", json={"members": []}).status_code == 422
+
+
+# --------------------------------------------------------------------------
+# parent: null => reuse `name`; a string => mint `name` under that existing
+# type. Passed through canonicalized; placement validity is the cascade's job.
+# --------------------------------------------------------------------------
+
+
+def test_parent_null_passes_through_as_reuse(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "vehicle", "parent": None})),
+    )
+    body = _post(_members(("i1", "boat"), ("i2", "car"))).json()
+    assert body["name"] == "vehicle"
+    assert body["parent"] is None  # reuse: no new parent edge target
+
+
+def test_parent_string_passes_through_canonicalized(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "generate_completion",
+        _make_completion(json.dumps({"name": "sedan", "parent": "Vehicles"})),
+    )
+    body = _post(_members(("i1", "a sedan"),)).json()
+    assert body["name"] == "sedan"
+    assert body["parent"] == "vehicle"  # canonicalized existing-parent name
+
+
+def test_missing_parent_key_is_reuse(monkeypatch):
+    monkeypatch.setattr(
+        m, "generate_completion", _make_completion(json.dumps({"name": "star"}))
+    )
+    body = _post(_members(("i1", "vega"),)).json()
+    assert body["parent"] is None


### PR DESCRIPTION
Closes #127.

Reverts `/type-cluster` to the as-designed contract (SPEC §3.2 as corrected 2026-06-06): the LLM **names** the cluster and returns **outliers**; the cascade **places**. Response shape `{name, parent, outliers}` — no chain, no ids, no sub-partitioning.

Per the 2026-06-06 design corrections: `_build_catalog_context()` lists **all** published types — including the domain roots `entity`/`concept`/`process` — as uniform `[t_xxxx]` aliased entries (roots are ordinary catalog citizens, valid as `parent` and as honest `name` reuse); only the structural nodes `node`/`root` (+ unminted `cognition`) are excluded. `_resolve_parent()` is fail-closed: `node`/`root` parents coerce with `bad_root_coerce`, off-catalog parents coerce closed-world.

Verification: 26/26 contract tests green (TDD); adversarial frame-check review vs SPEC corrected sections — all behavioral checks conform; review hygiene fixes applied (partition-era comment, dead `_MAX_CHAIN`, dead chain rendering). Collateral suites: 258 passed; JEPA test failures verified pre-existing.

Part of the naming-driven-typing v2 correction — vault `CORRECTION-PLAN.md` Phase 0.1.

**Do not merge without Chris's review.**