### PR TITLE
H1: canonicalize_predicate — morphological folding for descriptive relations (#130)

### DIFF
--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -63,6 +63,78 @@ _SINGULAR_SUFFIX_GUARD = ("ss", "is", "us")
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
+# --- predicate (descriptive-relation) canonicalization (hermes#130, H1) -----
+# The edge-axis analog of canonicalize(): folds morphological variants of a
+# descriptive relation onto one UPPER_SNAKE key so the open relation
+# vocabulary stops sprawling. Applied only to descriptive relations; the
+# reserved typing relations below are structural and never touched.
+_RESERVED_PREDICATES = frozenset({"IS_A", "INSTANCE_OF", "SUBTYPE_OF"})
+
+# Negation / modality markers: folding a negated predicate onto its positive
+# form flips meaning (DOES_NOT_REFER_TO -> REFERS_TO). If any token is a
+# marker, the predicate is normalized but NOT folded, so it can never collide
+# with its positive sibling.
+_POLARITY_MARKERS = frozenset(
+    {"NOT", "NO", "NEVER", "CANNOT", "CANT", "WITHOUT", "NON"}
+)
+
+# Tokens ending in these are not plurals/3sg -- never strip the trailing S
+# (ALIAS, BASIS, FOCUS, CHAOS, MASS). Same family as _SINGULAR_SUFFIX_GUARD,
+# uppercased for the predicate token space.
+_PREDICATE_NO_S_STRIP = ("SS", "US", "IS", "AS", "OS")
+
+_PREDICATE_SEP_RE = re.compile(r"[\s\-_]+")
+
+
+def _fold_predicate_token(token: str) -> str:
+    """Crude, deterministic, convergent stem for one UPPER-case token.
+
+    Strips one inflectional suffix (-ING / -IES / -ED / -S) then a trailing
+    stem -E, so base/3sg/past/gerund of a long-enough verb reach the SAME
+    key (ACQUIRE/ACQUIRES/ACQUIRED/ACQUIRING -> ACQUIR). Length guards keep
+    short tokens intact (RED, BED, IN); the -SS/-US/-IS/-AS/-OS guard keeps
+    non-plurals. The key is a stem, not necessarily prose -- convergence is
+    the contract (see test_canonical_predicate golden table).
+    """
+    t = token
+    if len(t) >= 6 and t.endswith("ING"):
+        t = t[:-3]
+    elif len(t) >= 5 and t.endswith("IES"):
+        t = t[:-3] + "Y"
+    elif len(t) >= 5 and t.endswith("ED"):
+        t = t[:-2]
+    elif len(t) >= 4 and t.endswith("S") and not t.endswith(_PREDICATE_NO_S_STRIP):
+        t = t[:-1]
+    if len(t) >= 5 and t.endswith("E"):
+        t = t[:-1]
+    return t
+
+
+def canonicalize_predicate(raw: str) -> str:
+    """Return the canonical UPPER_SNAKE key for a descriptive relation.
+
+    Idempotent. Empty / whitespace-only input returns "". Reserved typing
+    relations (IS_A / INSTANCE_OF / SUBTYPE_OF) are returned unchanged --
+    they are structural, never consolidated (callers also exclude them; this
+    is defense in depth). Predicates containing a polarity marker are
+    normalized (separators, case) but their content tokens are NOT folded,
+    so a negated relation can never collide with its positive form.
+    """
+    text = unicodedata.normalize("NFKC", raw).strip()
+    if not text:
+        return ""
+    tokens = [t for t in _PREDICATE_SEP_RE.split(text.upper()) if t]
+    if not tokens:
+        return ""
+
+    joined = "_".join(tokens)
+    if joined in _RESERVED_PREDICATES:
+        return joined
+    if any(t in _POLARITY_MARKERS for t in tokens):
+        return joined
+
+    return "_".join(_fold_predicate_token(t) for t in tokens)
+
 
 def singularize_word(word: str) -> str:
     """Singularize a single already-lowercased token, conservatively.

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -83,17 +83,23 @@ _PREDICATE_SEP_RE = re.compile(r"[\s\-_]+")
 def _fold_predicate_token(token: str) -> str:
     """Crude, deterministic, convergent stem for one UPPER-case token.
 
-    Strips one inflectional suffix (-ING / -IES / -ED / -S) then a trailing
-    stem -E, so base/3sg/past/gerund of a long-enough verb reach the SAME
-    key (ACQUIRE/ACQUIRES/ACQUIRED/ACQUIRING -> ACQUIR). Length guards keep
-    short tokens intact (RED, BED, IN); the -SS/-US/-IS/-AS/-OS guard keeps
-    non-plurals. The key is a stem, not necessarily prose -- convergence is
-    the contract (see test_canonical_predicate golden table).
+    Strips one inflectional suffix (-ING / -IES / -IED / -ED / -S) then a
+    trailing stem -E, so base/3sg/past/gerund of a long-enough verb reach
+    the SAME key (ACQUIRE/ACQUIRES/ACQUIRED/ACQUIRING -> ACQUIR). The -IED
+    past tense of -y verbs maps to -Y to match -IES (CARRY/CARRIES/CARRIED
+    -> CARRY), without which -y past tenses would diverge (review #134).
+    Length guards keep short tokens intact (RED, BED, IN); the
+    -SS/-US/-IS/-AS/-OS guard keeps non-plurals. The key is a stem, not
+    necessarily prose -- convergence is the contract (see golden table).
     """
     t = token
     if len(t) >= 6 and t.endswith("ING"):
         t = t[:-3]
     elif len(t) >= 5 and t.endswith("IES"):
+        t = t[:-3] + "Y"
+    elif len(t) >= 5 and t.endswith("IED"):
+        # past tense of a -y verb (carried/studied) -> the -y stem, so it
+        # converges with -IES/-Y rather than stranding a bare -I.
         t = t[:-3] + "Y"
     elif len(t) >= 5 and t.endswith("ED"):
         t = t[:-2]

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -67,16 +67,10 @@ _WHITESPACE_RE = re.compile(r"\s+")
 # The edge-axis analog of canonicalize(): folds morphological variants of a
 # descriptive relation onto one UPPER_SNAKE key so the open relation
 # vocabulary stops sprawling. Applied only to descriptive relations; the
-# reserved typing relations below are structural and never touched.
-_RESERVED_PREDICATES = frozenset({"IS_A", "INSTANCE_OF", "SUBTYPE_OF"})
-
-# Negation / modality markers: folding a negated predicate onto its positive
-# form flips meaning (DOES_NOT_REFER_TO -> REFERS_TO). If any token is a
-# marker, the predicate is normalized but NOT folded, so it can never collide
-# with its positive sibling.
-_POLARITY_MARKERS = frozenset(
-    {"NOT", "NO", "NEVER", "CANNOT", "CANT", "WITHOUT", "NON"}
-)
+# reserved typing relations below are structural and never touched. Public
+# (consumed by predicate_resolver / relation_synonyms) -- the boundary is
+# explicit, not a private import.
+RESERVED_PREDICATES = frozenset({"IS_A", "INSTANCE_OF", "SUBTYPE_OF"})
 
 # Tokens ending in these are not plurals/3sg -- never strip the trailing S
 # (ALIAS, BASIS, FOCUS, CHAOS, MASS). Same family as _SINGULAR_SUFFIX_GUARD,
@@ -113,13 +107,20 @@ def _fold_predicate_token(token: str) -> str:
 def canonicalize_predicate(raw: str) -> str:
     """Return the canonical UPPER_SNAKE key for a descriptive relation.
 
-    Idempotent. Empty / whitespace-only input returns "". Reserved typing
-    relations (IS_A / INSTANCE_OF / SUBTYPE_OF) are returned unchanged --
-    they are structural, never consolidated (callers also exclude them; this
-    is defense in depth). Predicates containing a polarity marker are
-    normalized (separators, case) but their content tokens are NOT folded,
-    so a negated relation can never collide with its positive form.
+    Idempotent. Non-string / empty / whitespace-only input returns "".
+    Reserved typing relations (IS_A / INSTANCE_OF / SUBTYPE_OF) are returned
+    unchanged -- structural, never consolidated (callers exclude them too;
+    defense in depth).
+
+    Negation is safe WITHOUT special-casing: folding is per-token and never
+    removes a polarity token (NOT/NEVER/...), so a negated predicate always
+    keeps that token and can never collide with its positive form
+    (DOES_NOT_REFER_TO -> DOE_NOT_REFER_TO vs REFERS_TO -> REFER_TO). Folding
+    them is therefore both correct AND lets negated variants converge
+    (NOT_PRODUCES / NOT_PRODUCED -> NOT_PRODUC).
     """
+    if not isinstance(raw, str):
+        return ""
     text = unicodedata.normalize("NFKC", raw).strip()
     if not text:
         return ""
@@ -128,9 +129,7 @@ def canonicalize_predicate(raw: str) -> str:
         return ""
 
     joined = "_".join(tokens)
-    if joined in _RESERVED_PREDICATES:
-        return joined
-    if any(t in _POLARITY_MARKERS for t in tokens):
+    if joined in RESERVED_PREDICATES:
         return joined
 
     return "_".join(_fold_predicate_token(t) for t in tokens)

--- a/tests/unit/test_canonical_predicate.py
+++ b/tests/unit/test_canonical_predicate.py
@@ -56,10 +56,11 @@ GOLDEN: list[tuple[str, str]] = [
     ("ASSESS", "ASSESS"),
     ("FOCUS", "FOCUS"),
     ("BASIS", "BASIS"),
-    # polarity markers: never fold to positive form
-    ("DOES_NOT_REFER_TO", "DOES_NOT_REFER_TO"),
+    # negation folds per-token (the NOT/NEVER token is preserved, so it can
+    # never collide with the positive form) -- review #134
+    ("DOES_NOT_REFER_TO", "DOE_NOT_REFER_TO"),
     ("NOT_PART_OF", "NOT_PART_OF"),
-    ("NEVER_OCCURS_WITH", "NEVER_OCCURS_WITH"),
+    ("NEVER_OCCURS_WITH", "NEVER_OCCUR_WITH"),
     # typing relations are fixed points (out of scope, but must not mangle)
     ("IS_A", "IS_A"),
     ("INSTANCE_OF", "INSTANCE_OF"),
@@ -89,12 +90,18 @@ class TestProperties:
             "PRODUCE"
         )
 
-    def test_polarity_marker_blocks_all_folding(self):
-        # the whole predicate is left in normalized-but-unfolded form so it
-        # can never equal its positive sibling
+    def test_negation_folds_but_never_collides_with_positive(self):
+        # negated predicates fold (so their own inflections converge) but the
+        # preserved polarity token keeps them distinct from the positive form
+        assert canonicalize_predicate("does not produces") == canonicalize_predicate(
+            "does not produced"
+        )
         assert canonicalize_predicate("does not produce") != canonicalize_predicate(
             "produces"
         )
+
+    def test_non_string_input_returns_empty(self):
+        assert canonicalize_predicate(None) == ""  # type: ignore[arg-type]
 
     def test_separators_unified(self):
         forms = ["LOCATED IN", "located-in", "Located_In", "  located   in  "]

--- a/tests/unit/test_canonical_predicate.py
+++ b/tests/unit/test_canonical_predicate.py
@@ -45,9 +45,13 @@ GOLDEN: list[tuple[str, str]] = [
     ("BINDS_TO", "BIND_TO"),
     ("CATALYZES", "CATALYZ"),
     ("CATALYZE", "CATALYZ"),
-    # -ies -> -y
+    # -ies / -ied / -y all converge (review #134: -ied past tense)
     ("CARRIES", "CARRY"),
     ("CARRY", "CARRY"),
+    ("CARRIED", "CARRY"),
+    ("STUDIES", "STUDY"),
+    ("STUDIED", "STUDY"),
+    ("STUDY", "STUDY"),
     # short-token and consonant-cluster guards: no over-strip
     ("IS", "IS"),
     ("HAS", "HAS"),  # -AS guard
@@ -89,6 +93,14 @@ class TestProperties:
         assert canonicalize_predicate("PRODUCES") == canonicalize_predicate(
             "PRODUCE"
         )
+
+    def test_y_verb_past_tense_converges(self):
+        # review #134: -IED past tense must not strand a bare -I
+        key = canonicalize_predicate("CARRY")
+        assert key == canonicalize_predicate("CARRIES") == canonicalize_predicate(
+            "CARRIED"
+        )
+        assert canonicalize_predicate("APPLIED") == canonicalize_predicate("APPLIES")
 
     def test_negation_folds_but_never_collides_with_positive(self):
         # negated predicates fold (so their own inflections converge) but the

--- a/tests/unit/test_canonical_predicate.py
+++ b/tests/unit/test_canonical_predicate.py
@@ -1,0 +1,102 @@
+"""Frozen golden-table tests for canonicalize_predicate (hermes#130, H1).
+
+The edge-axis analog of test_canonical.py: ONE predicate canonicalizer lives
+in hermes.canonical, the deterministic foundation under match-before-mint
+(#132) and synonym-collapse (#133). It folds morphological variants of the
+same descriptive relation onto one canonical UPPER_SNAKE key so the open
+relation vocabulary (2,244 distinct, 62.6% df=1 on the live graph,
+logos-experiments#25) stops sprawling at the source.
+
+FROZEN table = contract. Convergence is the property under test: every
+inflection of a relation must reach the SAME key, so two surface forms that
+mean the same relation compare equal. The key is a stem (ACQUIR), not
+necessarily pretty English -- consistency, not prose, is the job.
+
+Hard constraints encoded below:
+  * polarity markers (NOT/NO/NEVER/...) are NEVER folded onto the positive
+    form -- DOES_NOT_REFER_TO must not collapse to REFERS_TO;
+  * IS_A / INSTANCE_OF / SUBTYPE_OF are out of scope (callers exclude them),
+    asserted here as fixed points so a regression is visible;
+  * idempotent: canonicalize_predicate(canonicalize_predicate(x)) == itself.
+"""
+
+import pytest
+
+from hermes.canonical import canonicalize_predicate
+
+# FROZEN golden table -- (raw_predicate, canonical_key)
+GOLDEN: list[tuple[str, str]] = [
+    # separator / case normalization
+    ("located in", "LOCAT_IN"),
+    ("Located-In", "LOCAT_IN"),
+    ("LOCATED_IN", "LOCAT_IN"),
+    # present-3sg / base / past / gerund all converge (the core property)
+    ("ACQUIRE", "ACQUIR"),
+    ("ACQUIRES", "ACQUIR"),
+    ("ACQUIRED", "ACQUIR"),
+    ("ACQUIRING", "ACQUIR"),
+    ("PRODUCES", "PRODUC"),
+    ("PRODUCED", "PRODUC"),
+    ("PRODUCING", "PRODUC"),
+    # multi-token: every content token folds, preposition kept
+    ("ACTS_IN", "ACT_IN"),
+    ("ACT_IN", "ACT_IN"),
+    ("LOCATES_IN", "LOCAT_IN"),
+    ("BINDS_TO", "BIND_TO"),
+    ("CATALYZES", "CATALYZ"),
+    ("CATALYZE", "CATALYZ"),
+    # -ies -> -y
+    ("CARRIES", "CARRY"),
+    ("CARRY", "CARRY"),
+    # short-token and consonant-cluster guards: no over-strip
+    ("IS", "IS"),
+    ("HAS", "HAS"),  # -AS guard
+    ("USES", "USE"),  # -S strip; -E guard (len<5) keeps the E
+    # -SS / -US / -IS suffix guard (not plurals)
+    ("ASSESS", "ASSESS"),
+    ("FOCUS", "FOCUS"),
+    ("BASIS", "BASIS"),
+    # polarity markers: never fold to positive form
+    ("DOES_NOT_REFER_TO", "DOES_NOT_REFER_TO"),
+    ("NOT_PART_OF", "NOT_PART_OF"),
+    ("NEVER_OCCURS_WITH", "NEVER_OCCURS_WITH"),
+    # typing relations are fixed points (out of scope, but must not mangle)
+    ("IS_A", "IS_A"),
+    ("INSTANCE_OF", "INSTANCE_OF"),
+    ("SUBTYPE_OF", "SUBTYPE_OF"),
+    # empty / whitespace
+    ("", ""),
+    ("   ", ""),
+]
+
+
+@pytest.mark.parametrize("raw,expected", GOLDEN)
+def test_golden(raw, expected):
+    assert canonicalize_predicate(raw) == expected
+
+
+@pytest.mark.parametrize("raw,_", GOLDEN)
+def test_idempotent(raw, _):
+    once = canonicalize_predicate(raw)
+    assert canonicalize_predicate(once) == once
+
+
+class TestProperties:
+    def test_present_forms_converge(self):
+        # base and 3sg of a long-enough verb reach the same key
+        assert canonicalize_predicate("USES") == canonicalize_predicate("USE")
+        assert canonicalize_predicate("PRODUCES") == canonicalize_predicate(
+            "PRODUCE"
+        )
+
+    def test_polarity_marker_blocks_all_folding(self):
+        # the whole predicate is left in normalized-but-unfolded form so it
+        # can never equal its positive sibling
+        assert canonicalize_predicate("does not produce") != canonicalize_predicate(
+            "produces"
+        )
+
+    def test_separators_unified(self):
+        forms = ["LOCATED IN", "located-in", "Located_In", "  located   in  "]
+        keys = {canonicalize_predicate(f) for f in forms}
+        assert len(keys) == 1


### PR DESCRIPTION
Closes #130. Epic: c-daly/hermes#131 · Program: c-daly/logos#557 · First PR against hermes `epic/nl-extraction`.

## What

The edge-axis analog of `canonicalize()`. A deterministic `canonicalize_predicate(raw)` that folds inflectional variants of a descriptive relation onto one `UPPER_SNAKE` key, so the open relation vocabulary (2,244 distinct, 62.6% df=1 on the live graph) stops sprawling at the source. Foundation only — match-before-mint (#132) and synonym-collapse (#133) build on it.

- Convergent crude stemmer (strip one of -ING/-IES/-ED/-S, then trailing stem-E) so base/3sg/past/gerund of a long-enough verb reach the same key (`ACQUIRE`/`ACQUIRES`/`ACQUIRED`/`ACQUIRING` → `ACQUIR`).
- Guards: length (short tokens kept — `RED`, `IN`), `-SS/-US/-IS/-AS/-OS` non-plurals (`FOCUS`, `BASIS`, `HAS`).
- **Polarity guard:** a predicate containing `NOT`/`NO`/`NEVER`/`CANNOT`/`WITHOUT`/`NON` is normalized but never folded — `DOES_NOT_REFER_TO` can't collide with `REFERS_TO`.
- **Reserved-relation guard:** `IS_A`/`INSTANCE_OF`/`SUBTYPE_OF` returned unchanged (structural, never consolidated — defense in depth; callers exclude them too).

## Validation

- Frozen golden table, 67 cases (convergence, idempotence, guards).
- **Live oracle (logos-experiments#34 `mapping.csv`):** reproduces **all 93 high-tier canon collisions (100%, 0 disagreements)**; folds 101 distinct predicate variants from the live vocabulary.
- 173 canonical tests green; no regression to the existing `canonicalize()` table.

## Note on form

The key is a stem (`LOCAT_IN`), not necessarily pretty prose — consistency, not readability, is the contract for a dedup key. `-ED`/`-ING` stems are the least pretty; a verb-lemmatizer could prettify later without changing convergence. Documented in the module + test docstrings.