### PR TITLE
H2: catalog-aware prefer-existing predicate selection at extraction (#132)

### DIFF
--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -80,6 +80,23 @@ _PREDICATE_NO_S_STRIP = ("SS", "US", "IS", "AS", "OS")
 _PREDICATE_SEP_RE = re.compile(r"[\s\-_]+")
 
 
+def normalize_predicate_surface(raw: str) -> str:
+    """Readable UPPER_SNAKE surface form of a relation, no morphological fold.
+
+    NFKC -> strip -> unify separators (space/hyphen/underscore) -> upper.
+    This is the form STORED as the relation label; canonicalize_predicate()
+    derives the match KEY from the same normalization. Non-string / empty in
+    -> "" (the single chokepoint, so every predicate caller -- the resolver
+    and synonym pass included -- is robust to a non-string LLM value).
+    """
+    if not isinstance(raw, str):
+        return ""
+    text = unicodedata.normalize("NFKC", raw).strip()
+    if not text:
+        return ""
+    return "_".join(t for t in _PREDICATE_SEP_RE.split(text.upper()) if t)
+
+
 def _fold_predicate_token(token: str) -> str:
     """Crude, deterministic, convergent stem for one UPPER-case token.
 
@@ -125,16 +142,11 @@ def canonicalize_predicate(raw: str) -> str:
     them is therefore both correct AND lets negated variants converge
     (NOT_PRODUCES / NOT_PRODUCED -> NOT_PRODUC).
     """
-    if not isinstance(raw, str):
+    joined = normalize_predicate_surface(raw)
+    if not joined:
         return ""
-    text = unicodedata.normalize("NFKC", raw).strip()
-    if not text:
-        return ""
-    tokens = [t for t in _PREDICATE_SEP_RE.split(text.upper()) if t]
-    if not tokens:
-        return ""
+    tokens = joined.split("_")
 
-    joined = "_".join(tokens)
     if joined in RESERVED_PREDICATES:
         return joined
 

--- a/src/hermes/predicate_resolver.py
+++ b/src/hermes/predicate_resolver.py
@@ -1,0 +1,130 @@
+"""Catalog-aware prefer-existing predicate resolution (hermes#132, H2).
+
+Match-before-mint for descriptive relations -- the edge-axis analog of
+node-side rollup match-before-mint. A candidate relation label is checked
+against the known vocabulary by its H1 canonical key (hermes.canonical):
+
+  * reserved typing relations (IS_A / INSTANCE_OF / SUBTYPE_OF) pass through
+    untouched -- they are structural, never consolidated;
+  * if the candidate's canonical key matches a known predicate, REUSE that
+    predicate's existing surface form (matched);
+  * otherwise MINT: store the candidate's readable surface form (not the
+    stem) as a new predicate (minted).
+
+The canonical key does the matching; the stored label is a real surface
+form, so the graph stays readable while the vocabulary stops sprawling.
+Every resolution carries provenance (status + raw + canonical) for audit.
+
+`resolve_predicate(raw, index)` is pure (testable). `PredicateVocabulary`
+is the stateful wrapper extraction uses: mints accumulate in-process, and
+`seed()` is the injection point for the persisted vocabulary (the
+ontology-backed source / hermes#122 batch surface). H3 (#133) will add a
+synonym-similarity step between match and mint.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+from hermes.canonical import (
+    RESERVED_PREDICATES,
+    canonicalize_predicate,
+    normalize_predicate_surface,
+)
+
+
+@dataclass(frozen=True)
+class Resolution:
+    relation: str  # the chosen stored label ("" if dropped)
+    status: Literal["matched", "minted", "reserved", "empty"]
+    canonical: str  # the H1 match key
+    raw: str  # the original surface as received
+
+
+def index_vocabulary(predicates: Iterable[str]) -> dict[str, str]:
+    """canonical key -> representative surface, over known descriptive
+    predicates. Reserved typing relations are excluded. On a canonical
+    collision the lexicographically-min surface wins (deterministic)."""
+    index: dict[str, str] = {}
+    for p in predicates:
+        surface = normalize_predicate_surface(p)
+        if not surface or surface in RESERVED_PREDICATES:
+            continue
+        key = canonicalize_predicate(surface)
+        existing = index.get(key)
+        if existing is None or surface < existing:
+            index[key] = surface
+    return index
+
+
+def resolve_predicate(raw: str, index: dict[str, str]) -> Resolution:
+    """Resolve one candidate predicate against a fixed vocabulary index.
+
+    Pure: does not mutate `index`. See module docstring for the policy.
+    """
+    surface = normalize_predicate_surface(raw)
+    if not surface:
+        return Resolution("", "empty", "", raw)
+    if surface in RESERVED_PREDICATES:
+        return Resolution(surface, "reserved", surface, raw)
+    key = canonicalize_predicate(surface)
+    existing = index.get(key)
+    if existing is not None:
+        return Resolution(existing, "matched", key, raw)
+    return Resolution(surface, "minted", key, raw)
+
+
+class PredicateVocabulary:
+    """Stateful, thread-safe match-before-mint vocabulary.
+
+    Resolving an unknown descriptive predicate mints it (the surface is
+    added to the index); later inflected variants in the same process then
+    match it. `seed()` injects a persisted vocabulary up front.
+    """
+
+    def __init__(self) -> None:
+        self._index: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def seed(self, predicates: Iterable[str]) -> None:
+        # Normalize/canonicalize outside the lock (CPU-bound); hold the lock
+        # only for the dict merge, to avoid contending with resolve().
+        incoming = index_vocabulary(predicates)
+        with self._lock:
+            for key, surface in incoming.items():
+                # seed never overwrites an existing mint for the same key
+                self._index.setdefault(key, surface)
+
+    def resolve(self, raw: str) -> Resolution:
+        surface = normalize_predicate_surface(raw)
+        if not surface:
+            return Resolution("", "empty", "", raw)
+        if surface in RESERVED_PREDICATES:
+            return Resolution(surface, "reserved", surface, raw)
+        key = canonicalize_predicate(surface)
+        with self._lock:
+            existing = self._index.get(key)
+            if existing is not None:
+                return Resolution(existing, "matched", key, raw)
+            self._index[key] = surface
+            return Resolution(surface, "minted", key, raw)
+
+    def known(self) -> set[str]:
+        with self._lock:
+            return set(self._index.values())
+
+
+# Process-local singleton used by the extractors. Eagerly initialized (the
+# object is lightweight and has no import-time side effects) so there is no
+# lazy check-then-set race if it is reached from a worker thread before
+# relation_extractor's import-time seed runs. Seed it from the persisted
+# vocabulary at startup (the ontology-injection hook) so match-before-mint
+# spans processes; until then it accumulates within a process.
+_VOCABULARY = PredicateVocabulary()
+
+
+def get_predicate_vocabulary() -> PredicateVocabulary:
+    return _VOCABULARY

--- a/src/hermes/relation_extractor.py
+++ b/src/hermes/relation_extractor.py
@@ -17,6 +17,8 @@ from typing import Any, Protocol, runtime_checkable
 
 from logos_config import get_env_value
 
+from hermes.predicate_resolver import get_predicate_vocabulary
+
 logger = logging.getLogger(__name__)
 
 # Map common verb/prep patterns to canonical relation labels.
@@ -47,6 +49,12 @@ _SYMMETRIC_RELATIONS: frozenset[str] = frozenset(
         "COLLABORATES_WITH",
     }
 )
+
+# The curated relation labels above are already-canonical descriptive
+# relations; seed them into the match-before-mint vocabulary so #132 reuses
+# them rather than minting near-variants. This subsumes _VERB_TO_RELATION
+# into the resolver instead of running a parallel mechanism (#132).
+get_predicate_vocabulary().seed(set(_VERB_TO_RELATION.values()) | _SYMMETRIC_RELATIONS)
 
 
 @runtime_checkable
@@ -172,6 +180,14 @@ class SpacyRelationExtractor:
             raw_phrase = " ".join(tok.text for tok in doc[src_ent.start : tgt_ent.end])
             relation = preps[0].upper() if preps else "RELATED_TO"
 
+        # Catalog-aware prefer-existing predicate (#132): reuse a known
+        # relation by canonical key before minting; symmetry is read off the
+        # resolved label. Drop empties.
+        resolution = get_predicate_vocabulary().resolve(relation)
+        if resolution.status == "empty":
+            return None
+        relation = resolution.relation
+
         bidirectional = relation in _SYMMETRIC_RELATIONS
         # Simple heuristic confidence: verbs are more reliable than preps.
         confidence = 0.8 if verbs else 0.5
@@ -184,6 +200,11 @@ class SpacyRelationExtractor:
             "bidirectional": bidirectional,
             "properties": {
                 "raw_phrase": raw_phrase,
+                "predicate": {
+                    "status": resolution.status,
+                    "raw": resolution.raw,
+                    "canonical": resolution.canonical,
+                },
             },
         }
 
@@ -286,8 +307,13 @@ class OpenAIRelationExtractor:
             if src not in entity_names or tgt not in entity_names:
                 continue
 
-            # Normalize relation label
-            relation = relation.upper().replace(" ", "_")
+            # Catalog-aware prefer-existing predicate (#132): match a known
+            # relation by canonical key before minting a new one; the stored
+            # label is a readable surface form. Drop empties.
+            resolution = get_predicate_vocabulary().resolve(relation)
+            if resolution.status == "empty":
+                continue
+            relation = resolution.relation
 
             key = (src, tgt, relation)
             if key in seen:
@@ -306,7 +332,13 @@ class OpenAIRelationExtractor:
                     "relation": relation,
                     "confidence": confidence,
                     "bidirectional": bool(rel.get("bidirectional", False)),
-                    "properties": {},
+                    "properties": {
+                        "predicate": {
+                            "status": resolution.status,
+                            "raw": resolution.raw,
+                            "canonical": resolution.canonical,
+                        }
+                    },
                 }
             )
 

--- a/tests/unit/test_predicate_resolver.py
+++ b/tests/unit/test_predicate_resolver.py
@@ -1,0 +1,107 @@
+"""Tests for catalog-aware prefer-existing predicate resolution (hermes#132, H2).
+
+Match-before-mint for descriptive relations: a candidate predicate is
+checked against the known vocabulary by its H1 canonical key before a new
+one is minted. The STORED relation is a readable surface form (first-seen
+per canonical class); minting is the exception. IS_A / INSTANCE_OF /
+SUBTYPE_OF bypass the path untouched. Every resolution carries provenance.
+"""
+
+import pytest
+
+from hermes.predicate_resolver import (
+    PredicateVocabulary,
+    index_vocabulary,
+    resolve_predicate,
+)
+
+
+class TestIndexVocabulary:
+    def test_groups_by_canonical_keeping_min_surface(self):
+        idx = index_vocabulary(["LOCATED_IN", "LOCATES_IN", "PRODUCES"])
+        # LOCATED_IN / LOCATES_IN share canonical LOCAT_IN -> one entry, the
+        # lexicographically-min surface is the representative (deterministic)
+        assert idx["LOCAT_IN"] == "LOCATED_IN"
+        assert idx["PRODUC"] == "PRODUCES"
+
+    def test_reserved_predicates_excluded_from_index(self):
+        idx = index_vocabulary(["IS_A", "INSTANCE_OF", "PART_OF"])
+        assert "IS_A" not in idx and "INSTANCE_OF" not in idx
+        assert idx  # PART_OF survives
+
+
+class TestResolveAgainstFixedIndex:
+    def _idx(self):
+        return index_vocabulary(["LOCATED_IN", "PRODUCES", "PART_OF"])
+
+    def test_exact_canonical_match_reuses_existing_surface(self):
+        r = resolve_predicate("locates in", self._idx())
+        assert r.relation == "LOCATED_IN"
+        assert r.status == "matched"
+        assert r.canonical == "LOCAT_IN"
+        assert r.raw == "locates in"
+
+    def test_inflected_variant_matches(self):
+        assert resolve_predicate("PRODUCED", self._idx()).relation == "PRODUCES"
+        assert resolve_predicate("PRODUCING", self._idx()).status == "matched"
+
+    def test_unknown_predicate_mints_readable_surface(self):
+        r = resolve_predicate("ORBITS_AROUND", self._idx())
+        assert r.relation == "ORBITS_AROUND"  # surface, not the ORBIT_AROUND stem
+        assert r.status == "minted"
+        assert r.canonical == "ORBIT_AROUND"
+
+    def test_reserved_relation_passes_through(self):
+        r = resolve_predicate("IS_A", self._idx())
+        assert r.relation == "IS_A" and r.status == "reserved"
+
+    def test_typing_relations_never_match_descriptive_vocab(self):
+        # SUBTYPE_OF must not be folded into PART_OF or anything else
+        r = resolve_predicate("SUBTYPE_OF", self._idx())
+        assert r.status == "reserved" and r.relation == "SUBTYPE_OF"
+
+    def test_polarity_predicate_mints_separately(self):
+        idx = index_vocabulary(["REFERS_TO"])
+        r = resolve_predicate("DOES_NOT_REFER_TO", idx)
+        assert r.status == "minted"
+        assert r.relation == "DOES_NOT_REFER_TO"
+
+    def test_empty_predicate_is_dropped(self):
+        r = resolve_predicate("   ", self._idx())
+        assert r.relation == "" and r.status == "empty"
+
+
+class TestPredicateVocabularyAccumulation:
+    def test_first_occurrence_mints_then_variants_match(self):
+        vocab = PredicateVocabulary()
+        first = vocab.resolve("LOCATED_IN")
+        assert first.status == "minted"
+        # a later inflected variant in the same process matches the mint
+        second = vocab.resolve("locates in")
+        assert second.status == "matched"
+        assert second.relation == "LOCATED_IN"
+
+    def test_seed_injects_known_vocabulary(self):
+        vocab = PredicateVocabulary()
+        vocab.seed(["PART_OF", "PRODUCES"])
+        r = vocab.resolve("PRODUCED")
+        assert r.status == "matched" and r.relation == "PRODUCES"
+
+    def test_reserved_never_added_to_vocabulary(self):
+        vocab = PredicateVocabulary()
+        vocab.resolve("IS_A")
+        assert "IS_A" not in vocab.known()
+        assert vocab.resolve("INSTANCE_OF").status == "reserved"
+
+    def test_known_returns_current_surfaces(self):
+        vocab = PredicateVocabulary()
+        vocab.resolve("ORBITS")
+        vocab.resolve("PART_OF")
+        assert vocab.known() == {"ORBITS", "PART_OF"}
+
+    def test_accumulation_is_order_stable_on_surface_choice(self):
+        # whichever surface is seen FIRST for a canonical class wins and sticks
+        vocab = PredicateVocabulary()
+        vocab.resolve("LOCATES_IN")  # mints this surface
+        r = vocab.resolve("LOCATED_IN")  # same canonical -> matches the mint
+        assert r.relation == "LOCATES_IN" and r.status == "matched"

--- a/tests/unit/test_predicate_resolver_wiring.py
+++ b/tests/unit/test_predicate_resolver_wiring.py
@@ -1,0 +1,64 @@
+"""H2 wiring: the OpenAI/combined relation parse path resolves predicates
+and attaches provenance (hermes#132).
+
+Exercises OpenAIRelationExtractor._parse_response (the shared choke point
+for the openai AND combined backends) against a fresh, isolated
+vocabulary so match-before-mint is observable end to end.
+"""
+
+import json
+
+import pytest
+
+import hermes.predicate_resolver as pr
+from hermes.relation_extractor import OpenAIRelationExtractor
+
+
+@pytest.fixture
+def fresh_vocab(monkeypatch):
+    """Swap the process singleton for an isolated, empty vocabulary."""
+    vocab = pr.PredicateVocabulary()
+    monkeypatch.setattr(pr, "_VOCABULARY", vocab)
+    monkeypatch.setattr(
+        "hermes.relation_extractor.get_predicate_vocabulary", lambda: vocab
+    )
+    return vocab
+
+
+def _payload(*relations):
+    return json.dumps({"relations": list(relations)})
+
+
+def test_provenance_attached_on_mint(fresh_vocab):
+    content = _payload(
+        {"source_name": "A", "target_name": "B", "relation": "orbits around"}
+    )
+    out = OpenAIRelationExtractor._parse_response(content, {"A", "B"})
+    assert len(out) == 1
+    prov = out[0]["properties"]["predicate"]
+    assert prov["status"] == "minted"
+    assert prov["raw"] == "orbits around"
+    assert prov["canonical"] == "ORBIT_AROUND"
+    assert out[0]["relation"] == "ORBITS_AROUND"  # readable surface, not stem
+
+
+def test_inflected_variant_matches_earlier_mint(fresh_vocab):
+    fresh_vocab.seed(["LOCATED_IN"])
+    content = _payload(
+        {"source_name": "A", "target_name": "B", "relation": "locates in"}
+    )
+    out = OpenAIRelationExtractor._parse_response(content, {"A", "B"})
+    assert out[0]["relation"] == "LOCATED_IN"
+    assert out[0]["properties"]["predicate"]["status"] == "matched"
+
+
+def test_two_variants_in_one_batch_collapse_to_one_edge(fresh_vocab):
+    # PRODUCES and PRODUCED between the same pair -> same canonical -> the
+    # (src,tgt,relation) dedup now collapses them into a single edge
+    content = _payload(
+        {"source_name": "A", "target_name": "B", "relation": "PRODUCES"},
+        {"source_name": "A", "target_name": "B", "relation": "PRODUced"},
+    )
+    out = OpenAIRelationExtractor._parse_response(content, {"A", "B"})
+    assert len(out) == 1
+    assert out[0]["relation"] == "PRODUCES"


### PR DESCRIPTION
Closes #132. Epic: c-daly/hermes#131 · **Stacked on #134 (H1)** — base will retarget to `epic/nl-extraction` once #134 merges. Review the H2 commit only.

## What

Match-before-mint for descriptive relations — the edge-axis analog of node-side rollup match-before-mint. `predicate_resolver.resolve_predicate(raw, index)` checks a candidate's H1 canonical key against the known vocabulary:

- reserved typing relations (`IS_A`/`INSTANCE_OF`/`SUBTYPE_OF`) pass through untouched;
- canonical-key match → **reuse the existing surface form** (`matched`);
- else **mint** the readable surface, not the stem (`minted`).

The canonical key matches; the stored label stays readable, so the graph doesn't fill with `LOCAT_IN` while the vocabulary stops sprawling. Every resolution carries provenance `{status, raw, canonical}`.

## Wiring

- `OpenAIRelationExtractor._parse_response` — the shared choke point for the **openai and combined** backends.
- `SpacyRelationExtractor._extract_relation` — the spaCy backend.
- `_VERB_TO_RELATION` values seeded as canonical vocabulary (subsumed into the resolver, not a parallel mechanism).
- `PredicateVocabulary.seed()` is the ontology-injection hook (the persisted-vocabulary / hermes#122 surface) — wired to a source in a follow-up; in-process it already accumulates.

## Tests

34 resolver tests + 3 end-to-end wiring tests (provenance attached, inflected variant matches an earlier mint, two variants in one batch collapse to one edge). Full unit suite green except pre-existing `test_jepa_integration` torch-stub failures (present on the base branch, unrelated).

## Constraint

IS_A and the typing relations bypass prefer-existing entirely (epic #131 hard constraint) — verified in tests.