### PR TITLE
H3: descriptive-relation synonym-collapse endpoint (#133)

### DIFF
--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1892,7 +1892,13 @@ async def relation_synonyms(
     choices = result.get("choices") or []
     if not choices:
         raise HTTPException(status_code=502, detail="LLM returned no choices")
-    content = choices[0]["message"]["content"]
+    try:
+        content = choices[0]["message"]["content"]
+    except (KeyError, TypeError, IndexError) as exc:
+        logger.error("relation_synonyms: malformed LLM response shape: %s", exc)
+        raise HTTPException(
+            status_code=502, detail="LLM returned a malformed response"
+        ) from exc
 
     groups = parse_synonym_response(content, request.predicates)
     return RelationSynonymsResponse(

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1823,6 +1823,89 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
     )
 
 
+# ---------------------------------------------------------------------
+# Relation synonym-collapse: POST /relation-synonyms (hermes#133, H3)
+#
+# The relation-axis analog of /name-cluster: the LLM groups DESCRIPTIVE
+# relation synonyms (HAULS/DRAGS/CARRIES -> CARRIES). Server-side
+# validation (hermes.relation_synonyms) is fail-closed and enforces the
+# epic #131 hard constraint -- no group may contain a reserved typing
+# relation (IS_A/INSTANCE_OF/SUBTYPE_OF). The response is a PROPOSAL;
+# callers apply it through the existing propose->assert / review path.
+# ---------------------------------------------------------------------
+class RelationSynonymsRequest(BaseModel):
+    predicates: list[str] = Field(..., description="Descriptive relation labels.")
+    context: str | None = Field(
+        default=None, description="Optional domain context for disambiguation."
+    )
+    request_id: str | None = None
+
+
+class RelationSynonymGroup(BaseModel):
+    canonical: str
+    members: list[str]
+    confidence: float
+
+
+class RelationSynonymsResponse(BaseModel):
+    request_id: str | None = None
+    groups: list[RelationSynonymGroup]
+
+
+@app.post("/relation-synonyms", response_model=RelationSynonymsResponse)
+async def relation_synonyms(
+    request: RelationSynonymsRequest,
+) -> RelationSynonymsResponse:
+    """Propose descriptive-relation synonym groups (the relation naming pass).
+
+    The LLM is a codec: it proposes groupings + a canonical name from the
+    members; placement/assertion happen elsewhere. Reserved typing relations
+    are filtered from the prompt AND rejected in validation -- they are never
+    consolidated. Empty/insufficient input returns no groups (200, not 4xx):
+    "nothing to collapse" is a valid answer.
+    """
+    from hermes.relation_synonyms import (
+        build_synonym_messages,
+        parse_synonym_response,
+    )
+
+    if len([p for p in request.predicates if p and p.strip()]) < 2:
+        return RelationSynonymsResponse(request_id=request.request_id, groups=[])
+
+    messages = build_synonym_messages(request.predicates, context=request.context)
+    try:
+        result = await generate_completion(
+            messages=messages,
+            temperature=0.0,
+            max_tokens=1024,
+            metadata={"scenario": "relation_synonyms", "request_id": request.request_id},
+        )
+    except LLMProviderNotConfiguredError as exc:
+        logger.error("relation_synonyms: LLM provider not configured: %s", exc)
+        raise HTTPException(
+            status_code=503, detail="LLM provider not configured"
+        ) from exc
+    except LLMProviderError as exc:
+        logger.error("relation_synonyms: LLM provider error: %s", exc)
+        raise HTTPException(status_code=502, detail="LLM provider error") from exc
+
+    choices = result.get("choices") or []
+    if not choices:
+        raise HTTPException(status_code=502, detail="LLM returned no choices")
+    content = choices[0]["message"]["content"]
+
+    groups = parse_synonym_response(content, request.predicates)
+    return RelationSynonymsResponse(
+        request_id=request.request_id,
+        groups=[
+            RelationSynonymGroup(
+                canonical=g.canonical, members=g.members, confidence=g.confidence
+            )
+            for g in groups
+        ],
+    )
+
+
 class NameRelationshipRequest(BaseModel):
     source_name: str = Field(..., description="Source node name")
     target_name: str = Field(..., description="Target node name")

--- a/src/hermes/relation_synonyms.py
+++ b/src/hermes/relation_synonyms.py
@@ -1,0 +1,165 @@
+"""Descriptive-relation synonym-collapse pass (hermes#133, H3).
+
+The relation-axis analog of /name-cluster: the LLM detects DESCRIPTIVE
+relation synonyms (HAULS/DRAGS/CARRIES -> CARRIES) -- the linguistic-
+boundary work the H1 canonicalizer structurally cannot do. The LLM is a
+codec: it proposes synonym groupings + a canonical name; it does not decide
+placement or touch structure. This module owns the contract + fail-closed
+server-side validation only. The endpoint (main.py) calls the LLM; the
+graph is never mutated here -- output is a PROPOSAL routed through the
+existing propose->assert / review path.
+
+Hard rules (epic #131, enforced here, not trusted to the model):
+  * no group may contain a reserved typing relation (IS_A/INSTANCE_OF/
+    SUBTYPE_OF) -- those are structural and off-limits to consolidation;
+  * members must be among the submitted candidates (no hallucinations);
+  * members are deduped by H1 canonical key; a group that collapses to one
+    distinct relation is not a synonym group;
+  * the canonical label is an H1-normalized surface and must be a real
+    member.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+
+from hermes.canonical import (
+    _RESERVED_PREDICATES,
+    canonicalize_predicate,
+    normalize_predicate_surface,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SynonymGroup:
+    canonical: str
+    members: list[str]
+    confidence: float
+
+
+_SYSTEM_PROMPT = (
+    "You are a relation-vocabulary synonym detector for the LOGOS knowledge "
+    "graph. Given a list of DESCRIPTIVE relation labels, group together the "
+    "ones that mean the SAME relation (e.g. HAULS, DRAGS, CARRIES) and give "
+    "each group one canonical UPPER_SNAKE_CASE label chosen from its "
+    "members.\n\n"
+    "Hard rules:\n"
+    "- NEVER group the structural typing relations IS_A, INSTANCE_OF, or "
+    "SUBTYPE_OF with anything -- they are off-limits and must not appear in "
+    "any group.\n"
+    "- Only group labels that are TRUE synonyms (interchangeable in meaning "
+    "and direction); when unsure, leave a label out.\n"
+    "- Never invent labels: every member must come from the provided list.\n"
+    "- A group needs at least two distinct relations; do not emit singletons.\n\n"
+    'Return ONLY valid JSON: {"groups": [{"canonical": "...", "members": '
+    '["...", "..."], "confidence": 0.0-1.0}]}.'
+)
+
+
+def build_synonym_messages(
+    predicates: list[str], context: str | None = None
+) -> list[dict[str, str]]:
+    """Build the chat messages for the synonym pass.
+
+    Reserved typing relations are filtered out of the candidate list before
+    the model ever sees them (defense in depth -- the prompt also forbids
+    grouping them).
+    """
+    candidates = [
+        p
+        for p in predicates
+        if normalize_predicate_surface(p) not in _RESERVED_PREDICATES
+        and normalize_predicate_surface(p)
+    ]
+    ctx = f"Domain context: {context}\n\n" if context else ""
+    user = f"{ctx}Candidates: {', '.join(candidates)}\n\nGroup the synonyms."
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user},
+    ]
+
+
+def _coerce_json(content: str) -> dict | None:
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        match = re.search(r"```(?:json)?\s*(.*?)```", content, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(1))
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def parse_synonym_response(
+    content: str, candidates: list[str]
+) -> list[SynonymGroup]:
+    """Validate the LLM response into safe synonym groups. Fail closed:
+    anything malformed or rule-violating drops the offending group."""
+    data = _coerce_json(content)
+    if not isinstance(data, dict):
+        return []
+    raw_groups = data.get("groups")
+    if not isinstance(raw_groups, list):
+        return []
+
+    # candidate surfaces by canonical key (what the members may reference)
+    allowed_surface = {
+        normalize_predicate_surface(c)
+        for c in candidates
+        if normalize_predicate_surface(c)
+    }
+
+    out: list[SynonymGroup] = []
+    for grp in raw_groups:
+        if not isinstance(grp, dict):
+            continue
+        raw_members = grp.get("members")
+        if not isinstance(raw_members, list):
+            continue
+
+        members_surface: list[str] = []
+        seen_canon: set[str] = set()
+        bad = False
+        for m in raw_members:
+            if not isinstance(m, str):
+                bad = True
+                break
+            surface = normalize_predicate_surface(m)
+            if not surface or surface not in allowed_surface:
+                bad = True  # hallucinated or empty member
+                break
+            if surface in _RESERVED_PREDICATES:
+                bad = True  # reserved relation anywhere kills the group
+                break
+            canon = canonicalize_predicate(surface)
+            if canon not in seen_canon:
+                seen_canon.add(canon)
+                members_surface.append(surface)
+        if bad:
+            continue
+        if len(seen_canon) < 2:
+            continue  # not a real collapse
+
+        # canonical label: the LLM's pick if it is a real member, else the
+        # first member (deterministic) -- never a hallucinated/reserved name
+        proposed = normalize_predicate_surface(str(grp.get("canonical", "")))
+        canonical = (
+            proposed
+            if proposed in members_surface and proposed not in _RESERVED_PREDICATES
+            else members_surface[0]
+        )
+
+        confidence = grp.get("confidence", 0.7)
+        if not isinstance(confidence, (int, float)):
+            confidence = 0.7
+        confidence = max(0.0, min(1.0, float(confidence)))
+
+        out.append(SynonymGroup(canonical, members_surface, confidence))
+    return out

--- a/src/hermes/relation_synonyms.py
+++ b/src/hermes/relation_synonyms.py
@@ -27,7 +27,7 @@ import re
 from dataclasses import dataclass
 
 from hermes.canonical import (
-    _RESERVED_PREDICATES,
+    RESERVED_PREDICATES,
     canonicalize_predicate,
     normalize_predicate_surface,
 )
@@ -73,8 +73,8 @@ def build_synonym_messages(
     candidates = [
         p
         for p in predicates
-        if normalize_predicate_surface(p) not in _RESERVED_PREDICATES
-        and normalize_predicate_surface(p)
+        if (surf := normalize_predicate_surface(p))
+        and surf not in RESERVED_PREDICATES
     ]
     ctx = f"Domain context: {context}\n\n" if context else ""
     user = f"{ctx}Candidates: {', '.join(candidates)}\n\nGroup the synonyms."
@@ -85,6 +85,8 @@ def build_synonym_messages(
 
 
 def _coerce_json(content: str) -> dict | None:
+    if not isinstance(content, str):
+        return None
     try:
         return json.loads(content)
     except json.JSONDecodeError:
@@ -111,9 +113,7 @@ def parse_synonym_response(
 
     # candidate surfaces by canonical key (what the members may reference)
     allowed_surface = {
-        normalize_predicate_surface(c)
-        for c in candidates
-        if normalize_predicate_surface(c)
+        surf for c in candidates if (surf := normalize_predicate_surface(c))
     }
 
     out: list[SynonymGroup] = []
@@ -135,7 +135,7 @@ def parse_synonym_response(
             if not surface or surface not in allowed_surface:
                 bad = True  # hallucinated or empty member
                 break
-            if surface in _RESERVED_PREDICATES:
+            if surface in RESERVED_PREDICATES:
                 bad = True  # reserved relation anywhere kills the group
                 break
             canon = canonicalize_predicate(surface)
@@ -149,10 +149,15 @@ def parse_synonym_response(
 
         # canonical label: the LLM's pick if it is a real member, else the
         # first member (deterministic) -- never a hallucinated/reserved name
-        proposed = normalize_predicate_surface(str(grp.get("canonical", "")))
+        raw_canonical = grp.get("canonical")
+        proposed = (
+            normalize_predicate_surface(raw_canonical)
+            if isinstance(raw_canonical, str)
+            else ""
+        )
         canonical = (
             proposed
-            if proposed in members_surface and proposed not in _RESERVED_PREDICATES
+            if proposed in members_surface and proposed not in RESERVED_PREDICATES
             else members_surface[0]
         )
 

--- a/tests/test_relation_synonyms_endpoint.py
+++ b/tests/test_relation_synonyms_endpoint.py
@@ -1,0 +1,91 @@
+"""Tests for the /relation-synonyms endpoint (hermes#133, H3).
+
+The relation-axis naming pass: the LLM proposes descriptive-relation synonym
+groups; the endpoint validates fail-closed (epic #131: no reserved typing
+relation in any group). Every test monkeypatches generate_completion; no
+live LLM calls. Parse/validation rules are covered in
+tests/unit/test_relation_synonyms.py -- here we cover the HTTP contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+import hermes.main as m
+from fastapi.testclient import TestClient
+
+client = TestClient(m.app)
+
+
+def _make_completion(content: str):
+    async def fake_completion(messages, temperature=0.0, max_tokens=1024, **kwargs):
+        assert temperature == 0.0
+        fake_completion.last_messages = messages  # type: ignore[attr-defined]
+        return {"choices": [{"message": {"content": content}}]}
+
+    return fake_completion
+
+
+def _post(predicates, context=None):
+    body = {"predicates": predicates, "request_id": "r::0"}
+    if context is not None:
+        body["context"] = context
+    return client.post("/relation-synonyms", json=body)
+
+
+def test_groups_returned_and_canonicalized(monkeypatch):
+    content = json.dumps(
+        {"groups": [{"canonical": "carries", "members": ["HAULS", "DRAGS", "CARRIES"]}]}
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    resp = _post(["HAULS", "DRAGS", "CARRIES", "PRODUCES"])
+    assert resp.status_code == 200
+    groups = resp.json()["groups"]
+    assert len(groups) == 1
+    assert groups[0]["canonical"] == "CARRIES"
+    assert set(groups[0]["members"]) == {"HAULS", "DRAGS", "CARRIES"}
+
+
+def test_reserved_relation_group_rejected(monkeypatch):
+    content = json.dumps(
+        {"groups": [{"canonical": "IS_A", "members": ["IS_A", "SUBTYPE_OF"]}]}
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    resp = _post(["IS_A", "SUBTYPE_OF", "PART_OF", "CARRIES"])
+    assert resp.status_code == 200
+    assert resp.json()["groups"] == []
+
+
+def test_fewer_than_two_predicates_short_circuits(monkeypatch):
+    # must not even call the LLM
+    called = {"n": 0}
+
+    async def boom(*a, **k):
+        called["n"] += 1
+        return {"choices": [{"message": {"content": "{}"}}]}
+
+    monkeypatch.setattr(m, "generate_completion", boom)
+    resp = _post(["CARRIES"])
+    assert resp.status_code == 200
+    assert resp.json()["groups"] == []
+    assert called["n"] == 0
+
+
+def test_reserved_predicates_filtered_from_prompt(monkeypatch):
+    fake = _make_completion(json.dumps({"groups": []}))
+    monkeypatch.setattr(m, "generate_completion", fake)
+    _post(["CARRIES", "HAULS", "IS_A"], context="logistics")
+    user = [msg for msg in fake.last_messages if msg["role"] == "user"][0]["content"]
+    assert "IS_A" not in user.split("Candidates:")[-1]
+    assert "logistics" in user
+
+
+def test_llm_not_configured_returns_503(monkeypatch):
+    from hermes.llm import LLMProviderNotConfiguredError
+
+    async def not_configured(*a, **k):
+        raise LLMProviderNotConfiguredError("no key")
+
+    monkeypatch.setattr(m, "generate_completion", not_configured)
+    resp = _post(["HAULS", "CARRIES"])
+    assert resp.status_code == 503

--- a/tests/unit/test_relation_synonyms.py
+++ b/tests/unit/test_relation_synonyms.py
@@ -1,0 +1,115 @@
+"""Fail-closed contract tests for the relation synonym-collapse pass (#133, H3).
+
+The LLM proposes descriptive-relation synonym groups (HAULS/DRAGS/CARRIES ->
+CARRIES); this module validates server-side. The hard rules (epic #131):
+no group may contain a reserved typing relation; members must come from the
+submitted candidates (no hallucinated predicates); a "group" of one is not a
+collapse; the canonical label is H1-normalized. Output is a PROPOSAL.
+"""
+
+import json
+
+import pytest
+
+from hermes.relation_synonyms import (
+    build_synonym_messages,
+    parse_synonym_response,
+)
+
+
+def _content(*groups):
+    return json.dumps({"groups": list(groups)})
+
+
+CANDIDATES = ["HAULS", "DRAGS", "CARRIES", "PRODUCES", "MAKES", "IS_A", "PART_OF"]
+
+
+class TestParseHappyPath:
+    def test_valid_group_kept_and_canonicalized(self):
+        out = parse_synonym_response(
+            _content({"canonical": "carries", "members": ["HAULS", "DRAGS", "CARRIES"]}),
+            CANDIDATES,
+        )
+        assert len(out) == 1
+        g = out[0]
+        assert g.canonical == "CARRIES"  # normalized surface
+        assert set(g.members) == {"HAULS", "DRAGS", "CARRIES"}
+        assert 0.0 <= g.confidence <= 1.0
+
+    def test_confidence_passed_through_and_clamped(self):
+        out = parse_synonym_response(
+            _content(
+                {"canonical": "MAKES", "members": ["PRODUCES", "MAKES"], "confidence": 2.0}
+            ),
+            CANDIDATES,
+        )
+        assert out[0].confidence == 1.0
+
+
+class TestFailClosed:
+    def test_group_with_reserved_relation_is_dropped(self):
+        out = parse_synonym_response(
+            _content({"canonical": "IS_A", "members": ["IS_A", "PART_OF"]}),
+            CANDIDATES,
+        )
+        assert out == []
+
+    def test_reserved_member_anywhere_drops_the_group(self):
+        out = parse_synonym_response(
+            _content({"canonical": "CARRIES", "members": ["CARRIES", "INSTANCE_OF"]}),
+            CANDIDATES + ["INSTANCE_OF"],
+        )
+        assert out == []
+
+    def test_hallucinated_member_drops_the_group(self):
+        out = parse_synonym_response(
+            _content({"canonical": "CARRIES", "members": ["CARRIES", "TELEPORTS"]}),
+            CANDIDATES,
+        )
+        assert out == []
+
+    def test_singleton_group_is_not_a_collapse(self):
+        out = parse_synonym_response(
+            _content({"canonical": "CARRIES", "members": ["CARRIES"]}),
+            CANDIDATES,
+        )
+        assert out == []
+
+    def test_members_dedup_by_canonical_then_singleton_dropped(self):
+        # CARRIES + CARRY are the same canonical -> effectively one member
+        out = parse_synonym_response(
+            _content({"canonical": "CARRIES", "members": ["CARRIES", "CARRY"]}),
+            CANDIDATES + ["CARRY"],
+        )
+        assert out == []
+
+    def test_malformed_json_returns_empty(self):
+        assert parse_synonym_response("not json", CANDIDATES) == []
+
+    def test_missing_groups_key_returns_empty(self):
+        assert parse_synonym_response(json.dumps({"x": 1}), CANDIDATES) == []
+
+    def test_canonical_not_among_members_is_repaired_to_a_member(self):
+        # if the LLM names a canonical that isn't one of the members, keep the
+        # group but the canonical must be a real member's surface
+        out = parse_synonym_response(
+            _content({"canonical": "TRANSPORTS", "members": ["HAULS", "CARRIES"]}),
+            CANDIDATES,
+        )
+        assert len(out) == 1
+        assert out[0].canonical in {"HAULS", "CARRIES"}
+
+
+class TestPromptConstruction:
+    def test_messages_list_the_candidates_and_forbid_is_a(self):
+        msgs = build_synonym_messages(["HAULS", "CARRIES"], context="cargo domain")
+        blob = " ".join(m["content"] for m in msgs)
+        assert "HAULS" in blob and "CARRIES" in blob
+        assert "IS_A" in blob  # the prompt must state the exclusion
+        assert "cargo domain" in blob
+
+    def test_reserved_candidates_filtered_from_the_prompt(self):
+        msgs = build_synonym_messages(["CARRIES", "IS_A", "SUBTYPE_OF"])
+        user = [m for m in msgs if m["role"] == "user"][0]["content"]
+        # IS_A/SUBTYPE_OF must not be offered as groupable candidates
+        assert "SUBTYPE_OF" not in user.split("Candidates:")[-1]


### PR DESCRIPTION
Closes #133. Epic: c-daly/hermes#131 · **Stacked on #135 (H2) → #134 (H1)** — base retargets to `epic/nl-extraction` as the stack merges. Review the H3 commit only.

## What

`POST /relation-synonyms` — the relation-axis analog of `/name-cluster`. The LLM groups descriptive-relation synonyms (`HAULS`/`DRAGS`/`CARRIES` → `CARRIES`) — the linguistic-boundary work H1's canonicalizer structurally can't do. The LLM is a codec: it proposes groupings + a canonical name from the members; placement/assertion happen elsewhere.

`relation_synonyms.py` owns the contract + **fail-closed** validation:
- reserved typing relations (`IS_A`/`INSTANCE_OF`/`SUBTYPE_OF`) are filtered from the prompt **and** rejected in any group (epic #131 hard constraint);
- every member must be a submitted candidate (no hallucinated predicates);
- members deduped by H1 canonical key; a group collapsing to one distinct relation is dropped;
- canonical label is an H1-normalized surface and must be a real member.

Output is a **PROPOSAL** — the endpoint never mutates the graph; callers apply via the existing propose→assert / review path.

## Two consumers (per the ticket)

Write-time ambiguity adjudication for H2, and a Sophia-side backlog rollup pass (separate ticket there) — the LLM half that bridges the ~39% of df=1 predicates logos-experiments#34's crude stemmer can't reach.

## Tests

17: 12 fail-closed parse/validation + 5 HTTP contract (reserved rejected, <2 predicates short-circuits without calling the LLM, reserved filtered from prompt, 503 on no provider), mirroring the `/type-cluster` mock pattern. Full suite 402 passed (excl. pre-existing `test_jepa_integration` torch-stub failures).