### PR TITLE
H4: seed predicate vocabulary from the Redis relation snapshot (#137)

### DIFF
--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -288,6 +288,7 @@ _type_registry_redis_client = None
 _relation_registry = None
 _relation_registry_event_bus = None
 _relation_registry_listener = None
+_relation_registry_redis_client = None
 
 
 @asynccontextmanager
@@ -345,29 +346,6 @@ async def lifespan(app: FastAPI):  # type: ignore
         )
         _type_registry_listener.start()
         logger.info("TypeRegistry subscribed to ontology changes")
-
-        # Seed the match-before-mint predicate vocabulary from the same
-        # Sophia sync (sophia#190 -> hermes#137). Own EventBus/listener
-        # because redis-py keeps one handler per channel; Redis pub/sub
-        # broadcasts the event to both.
-        from hermes.predicate_resolver import get_predicate_vocabulary
-        from hermes.relation_registry import RelationRegistry
-
-        _relation_registry = RelationRegistry(
-            _type_registry_redis_client, get_predicate_vocabulary()
-        )
-        _relation_registry_event_bus = EventBus(_redis_config)
-        _relation_registry_event_bus.subscribe(
-            "logos:sophia:proposal_processed",
-            _relation_registry.on_proposal_processed,
-        )
-        _relation_registry_listener = threading.Thread(
-            target=_relation_registry_event_bus.listen,
-            daemon=True,
-            name="relation-registry-listener",
-        )
-        _relation_registry_listener.start()
-        logger.info("RelationRegistry seeded and subscribed to ontology changes")
     except Exception:
         logger.warning(
             "TypeRegistry unavailable — ontology type sync disabled",
@@ -382,6 +360,56 @@ async def lifespan(app: FastAPI):  # type: ignore
         _type_registry = None
         _type_registry_event_bus = None
         _type_registry_listener = None
+
+    # Seed the match-before-mint predicate vocabulary from the same Sophia
+    # sync (sophia#190 -> hermes#137). INDEPENDENT fail-soft block: a failure
+    # here must not disable the already-running TypeRegistry (and vice versa),
+    # and its own thread is cleaned up on failure. Own redis client +
+    # EventBus/listener because redis-py keeps one handler per channel; Redis
+    # pub/sub broadcasts the event to both.
+    global _relation_registry_redis_client
+    try:
+        import redis as _redis_mod
+
+        from hermes.predicate_resolver import get_predicate_vocabulary
+        from hermes.relation_registry import RelationRegistry
+        from logos_events import EventBus  # type: ignore[import-not-found]
+
+        _relation_registry_redis_client = _redis_mod.from_url(RedisConfig().url)
+        _relation_registry = RelationRegistry(
+            _relation_registry_redis_client, get_predicate_vocabulary()
+        )
+        _relation_registry_event_bus = EventBus(RedisConfig())
+        _relation_registry_event_bus.subscribe(
+            "logos:sophia:proposal_processed",
+            _relation_registry.on_proposal_processed,
+        )
+        _relation_registry_listener = threading.Thread(
+            target=_relation_registry_event_bus.listen,
+            daemon=True,
+            name="relation-registry-listener",
+        )
+        _relation_registry_listener.start()
+        logger.info("RelationRegistry seeded and subscribed to ontology changes")
+    except Exception:
+        logger.warning(
+            "RelationRegistry unavailable — predicate vocabulary sync disabled",
+            exc_info=True,
+        )
+        if _relation_registry_event_bus is not None:
+            try:
+                _relation_registry_event_bus.stop()
+            except Exception:
+                pass
+        if _relation_registry_redis_client is not None:
+            try:
+                _relation_registry_redis_client.close()
+            except Exception:
+                pass
+            _relation_registry_redis_client = None
+        _relation_registry = None
+        _relation_registry_event_bus = None
+        _relation_registry_listener = None
     logger.info("Hermes API startup complete")
     yield
     # Shutdown
@@ -404,6 +432,11 @@ async def lifespan(app: FastAPI):  # type: ignore
             logger.warning("RelationRegistry listener thread did not stop within 5s")
         else:
             logger.info("RelationRegistry event listener stopped")
+    if _relation_registry_redis_client is not None:
+        try:
+            _relation_registry_redis_client.close()
+        except Exception:
+            pass
     if _type_registry_redis_client is not None:
         _type_registry_redis_client.close()
     milvus_client.disconnect_milvus()

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -285,6 +285,9 @@ _type_registry = None
 _type_registry_event_bus = None
 _type_registry_listener = None
 _type_registry_redis_client = None
+_relation_registry = None
+_relation_registry_event_bus = None
+_relation_registry_listener = None
 
 
 @asynccontextmanager
@@ -314,6 +317,7 @@ async def lifespan(app: FastAPI):  # type: ignore
     milvus_client.initialize_milvus()
     # Initialize TypeRegistry for ontology type sync
     global _type_registry, _type_registry_event_bus, _type_registry_listener, _type_registry_redis_client
+    global _relation_registry, _relation_registry_event_bus, _relation_registry_listener
     try:
         from hermes.type_registry import TypeRegistry
         import redis
@@ -341,6 +345,29 @@ async def lifespan(app: FastAPI):  # type: ignore
         )
         _type_registry_listener.start()
         logger.info("TypeRegistry subscribed to ontology changes")
+
+        # Seed the match-before-mint predicate vocabulary from the same
+        # Sophia sync (sophia#190 -> hermes#137). Own EventBus/listener
+        # because redis-py keeps one handler per channel; Redis pub/sub
+        # broadcasts the event to both.
+        from hermes.predicate_resolver import get_predicate_vocabulary
+        from hermes.relation_registry import RelationRegistry
+
+        _relation_registry = RelationRegistry(
+            _type_registry_redis_client, get_predicate_vocabulary()
+        )
+        _relation_registry_event_bus = EventBus(_redis_config)
+        _relation_registry_event_bus.subscribe(
+            "logos:sophia:proposal_processed",
+            _relation_registry.on_proposal_processed,
+        )
+        _relation_registry_listener = threading.Thread(
+            target=_relation_registry_event_bus.listen,
+            daemon=True,
+            name="relation-registry-listener",
+        )
+        _relation_registry_listener.start()
+        logger.info("RelationRegistry seeded and subscribed to ontology changes")
     except Exception:
         logger.warning(
             "TypeRegistry unavailable — ontology type sync disabled",
@@ -368,6 +395,15 @@ async def lifespan(app: FastAPI):  # type: ignore
             logger.warning("TypeRegistry listener thread did not stop within 5s")
         else:
             logger.info("TypeRegistry event listener stopped")
+    # Stop RelationRegistry event listener (shares the redis client closed above)
+    if _relation_registry_event_bus is not None:
+        _relation_registry_event_bus.stop()
+    if _relation_registry_listener is not None:
+        _relation_registry_listener.join(timeout=5)
+        if _relation_registry_listener.is_alive():
+            logger.warning("RelationRegistry listener thread did not stop within 5s")
+        else:
+            logger.info("RelationRegistry event listener stopped")
     if _type_registry_redis_client is not None:
         _type_registry_redis_client.close()
     milvus_client.disconnect_milvus()

--- a/src/hermes/relation_registry.py
+++ b/src/hermes/relation_registry.py
@@ -61,10 +61,15 @@ class RelationRegistry:
                 type(data).__name__,
             )
             return
-        # seed() filters reserved typing relations and dedups by canonical key
+        # seed() filters reserved typing relations and dedups by canonical
+        # key, so the number actually added is <= the raw snapshot size.
+        before = len(self._vocabulary.known())
         self._vocabulary.seed(data.keys())
+        added = len(self._vocabulary.known()) - before
         logger.info(
-            "RelationRegistry seeded %d relations from Redis", len(data)
+            "RelationRegistry: +%d relations from a %d-entry snapshot",
+            added,
+            len(data),
         )
 
     def on_proposal_processed(self, event: dict) -> None:

--- a/src/hermes/relation_registry.py
+++ b/src/hermes/relation_registry.py
@@ -1,0 +1,73 @@
+"""RelationRegistry — seeds the predicate vocabulary from Redis + pub/sub.
+
+The edge-axis analog of TypeRegistry (hermes#137, H4). Reads the
+descriptive-relation snapshot Sophia publishes to ``logos:ontology:relations``
+(sophia#190) and seeds the match-before-mint ``PredicateVocabulary`` on boot,
+re-seeding on every ``logos:sophia:proposal_processed`` event so newly-minted
+relations propagate to every Hermes worker. Redis is the shared substrate, so
+this makes match-before-mint cross-process; the EventBus reload keeps it
+fresh.
+
+Unlike TypeRegistry this holds no state of its own — the vocabulary is the
+store. Seeding is additive (``PredicateVocabulary.seed`` uses setdefault), so
+a reload never drops a predicate minted in-process that has not yet
+round-tripped back through Sophia's next snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from hermes.predicate_resolver import PredicateVocabulary
+
+logger = logging.getLogger(__name__)
+
+
+class RelationRegistry:
+    """Syncs the descriptive-relation vocabulary from Redis into the
+    match-before-mint vocabulary."""
+
+    REDIS_KEY = "logos:ontology:relations"
+
+    def __init__(self, redis_client: Any, vocabulary: PredicateVocabulary) -> None:
+        self._redis = redis_client
+        self._vocabulary = vocabulary
+        self._load_and_seed()
+
+    def _load_and_seed(self) -> None:
+        """Read the relation snapshot from Redis and seed the vocabulary.
+
+        Fail-soft: a missing key, malformed snapshot, or Redis error leaves
+        the vocabulary as-is (extraction still works with whatever it has).
+        """
+        try:
+            raw = self._redis.get(self.REDIS_KEY)
+        except Exception:
+            logger.exception("RelationRegistry: failed to read %s", self.REDIS_KEY)
+            return
+        if raw is None:
+            logger.info("RelationRegistry: no relation snapshot in Redis")
+            return
+        try:
+            data = json.loads(raw)
+        except (TypeError, json.JSONDecodeError):
+            logger.exception("RelationRegistry: malformed relation snapshot")
+            return
+        if not isinstance(data, dict):
+            logger.error(
+                "RelationRegistry: invalid snapshot type %s (expected dict)",
+                type(data).__name__,
+            )
+            return
+        # seed() filters reserved typing relations and dedups by canonical key
+        self._vocabulary.seed(data.keys())
+        logger.info(
+            "RelationRegistry seeded %d relations from Redis", len(data)
+        )
+
+    def on_proposal_processed(self, event: dict) -> None:
+        """EventBus callback — re-read the snapshot and re-seed (additive)."""
+        logger.info("RelationRegistry: proposal_processed event, reloading relations")
+        self._load_and_seed()

--- a/tests/unit/test_relation_registry.py
+++ b/tests/unit/test_relation_registry.py
@@ -1,0 +1,87 @@
+"""Tests for RelationRegistry (hermes#137, H4).
+
+Mirrors TypeRegistry: reads the descriptive-relation snapshot Sophia
+publishes to logos:ontology:relations (sophia#190) and seeds the
+match-before-mint PredicateVocabulary, on boot and on each
+proposal_processed event. Fail-soft.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from hermes.predicate_resolver import PredicateVocabulary
+from hermes.relation_registry import RelationRegistry
+
+
+def _redis_with(snapshot):
+    r = MagicMock()
+    r.get.return_value = json.dumps(snapshot) if snapshot is not None else None
+    return r
+
+
+def test_seeds_vocabulary_from_snapshot_on_boot():
+    vocab = PredicateVocabulary()
+    redis = _redis_with({"LOCATED_IN": {"edge_count": 12}, "PRODUCES": {"edge_count": 5}})
+    RelationRegistry(redis, vocab)
+    assert vocab.known() == {"LOCATED_IN", "PRODUCES"}
+    # reads the relation key, not the type key
+    assert redis.get.call_args[0][0] == "logos:ontology:relations"
+
+
+def test_seeded_vocabulary_matches_inflected_variant():
+    vocab = PredicateVocabulary()
+    RelationRegistry(_redis_with({"LOCATED_IN": {"edge_count": 3}}), vocab)
+    r = vocab.resolve("locates in")
+    assert r.status == "matched" and r.relation == "LOCATED_IN"
+
+
+def test_missing_snapshot_leaves_vocabulary_empty_no_error():
+    vocab = PredicateVocabulary()
+    RelationRegistry(_redis_with(None), vocab)
+    assert vocab.known() == set()
+
+
+def test_redis_failure_is_swallowed():
+    vocab = PredicateVocabulary()
+    redis = MagicMock()
+    redis.get.side_effect = RuntimeError("redis down")
+    RelationRegistry(redis, vocab)  # must not raise
+    assert vocab.known() == set()
+
+
+def test_non_dict_snapshot_is_ignored():
+    vocab = PredicateVocabulary()
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(["LOCATED_IN"])  # wrong shape
+    RelationRegistry(redis, vocab)
+    assert vocab.known() == set()
+
+
+def test_reload_on_event_seeds_new_relations():
+    vocab = PredicateVocabulary()
+    redis = _redis_with({"LOCATED_IN": {"edge_count": 1}})
+    reg = RelationRegistry(redis, vocab)
+    # Sophia publishes a new relation; next snapshot includes it
+    redis.get.return_value = json.dumps(
+        {"LOCATED_IN": {"edge_count": 1}, "ORBITS_AROUND": {"edge_count": 2}}
+    )
+    reg.on_proposal_processed({"event_type": "proposal_processed"})
+    assert "ORBITS_AROUND" in vocab.known()
+
+
+def test_reload_preserves_in_process_mints():
+    # a predicate minted in-process (not yet in any snapshot) must survive a
+    # reload -- seed() is additive (the mint round-trips via Sophia later)
+    vocab = PredicateVocabulary()
+    reg = RelationRegistry(_redis_with({"LOCATED_IN": {"edge_count": 1}}), vocab)
+    vocab.resolve("TELEPORTS")  # in-process mint
+    reg.on_proposal_processed({})
+    assert "TELEPORTS" in vocab.known()
+
+
+def test_reserved_relation_in_snapshot_never_seeded():
+    # defense in depth: even if a reserved relation leaks into the snapshot,
+    # the vocabulary never accepts it
+    vocab = PredicateVocabulary()
+    RelationRegistry(_redis_with({"IS_A": {"edge_count": 9}}), vocab)
+    assert "IS_A" not in vocab.known()


### PR DESCRIPTION
Closes #137. Epic: c-daly/hermes#131 · **Stacked on #136 (H3) → #135 → #134** — base retargets to `epic/nl-extraction` as the stack merges. Depends on c-daly/sophia#190 (PR c-daly/sophia#191) for the published snapshot. Review the H4 commit only.

## What

`RelationRegistry`, the edge-axis analog of `TypeRegistry`. Reads the descriptive-relation snapshot Sophia publishes to `logos:ontology:relations` (sophia#190) and seeds the match-before-mint `PredicateVocabulary` — on boot, and on every `proposal_processed` EventBus event.

This closes the loop the relation axis was missing: Redis is the shared substrate, so seeding makes match-before-mint **cross-process** (no per-worker re-minting), and the event reload keeps it fresh — a predicate minted in one worker lands as an edge → Sophia's next snapshot includes it → reload pushes it to every worker.

## Design notes

- **Additive seeding.** `PredicateVocabulary.seed()` uses `setdefault`, so a reload never drops a predicate minted in-process that hasn't yet round-tripped through Sophia's snapshot.
- **Own EventBus + listener.** `redis-py` keeps one handler per channel, so this can't share TypeRegistry's subscription; Redis pub/sub broadcasts the event to both. Mirrors the TypeRegistry lifespan block, with matching shutdown cleanup.
- **Fail-soft throughout.** Missing key, malformed/non-dict snapshot, or Redis down → vocabulary left as-is; extraction still works with the in-process seed.
- **Reserved relations** can never enter the vocabulary even if they leak into the snapshot (`seed()` filters them; tested).

## Tests

8 registry tests (boot seed, inflected-variant match, missing/malformed/non-dict snapshot, Redis failure, event reload adds new + preserves in-process mints, reserved never seeded). `main.py` imports clean; full suite 420 passed (excl. pre-existing jepa torch-stub failures).