### PR TITLE
feat: POST /embed_text_batch — rate-safe bulk embedding

### DIFF
--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -458,6 +458,9 @@ class EmbedTextResponse(BaseModel):
     embedding_id: str = Field(..., description="Unique identifier for this embedding")
 
 
+MAX_EMBED_BATCH = 1024
+
+
 class EmbedTextBatchRequest(BaseModel):
     texts: List[str] = Field(..., description="Texts to embed in one batch call.")
     model: str = Field(default="default", description="Optional embedding model id.")
@@ -816,12 +819,21 @@ async def embed_text_batch(request: EmbedTextBatchRequest) -> EmbedTextBatchResp
         span.set_attribute("embedding.batch_size", len(request.texts))
         if not request.texts:
             return EmbedTextBatchResponse(embeddings=[])
+        if len(request.texts) > MAX_EMBED_BATCH:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"texts exceeds the {MAX_EMBED_BATCH}-item batch cap; "
+                    "split into smaller batches (OpenAI per-request token limits "
+                    "and Milvus persist fan-out)"
+                ),
+            )
         if any(not t or not t.strip() for t in request.texts):
             raise HTTPException(
                 status_code=400, detail="texts must not contain empty/blank entries"
             )
         try:
-            results = await generate_embeddings_batch(request.texts)
+            results = await generate_embeddings_batch(request.texts, request.model)
             return EmbedTextBatchResponse(
                 embeddings=[
                     EmbedTextResponse(

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -135,6 +135,7 @@ from hermes.embedding_provider import get_visual_embedding_providers
 from hermes.proposal_builder import ProposalBuilder
 from hermes.services import (
     generate_embedding,
+    generate_embeddings_batch,
     generate_llm_response,
     get_llm_health,
     process_nlp,
@@ -455,6 +456,17 @@ class EmbedTextResponse(BaseModel):
     dimension: int = Field(..., description="Embedding dimension")
     model: str = Field(..., description="Model used for embedding")
     embedding_id: str = Field(..., description="Unique identifier for this embedding")
+
+
+class EmbedTextBatchRequest(BaseModel):
+    texts: List[str] = Field(..., description="Texts to embed in one batch call.")
+    model: str = Field(default="default", description="Optional embedding model id.")
+
+
+class EmbedTextBatchResponse(BaseModel):
+    embeddings: List[EmbedTextResponse] = Field(
+        ..., description="One embedding per input text, in input order."
+    )
 
 
 class LLMMessage(BaseModel):
@@ -790,6 +802,43 @@ async def embed_text(request: EmbedTextRequest) -> EmbedTextResponse:
             span.record_exception(e)
             span.set_status(StatusCode.ERROR, str(e))
             logger.error(f"Embedding error: {str(e)}")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.post("/embed_text_batch", response_model=EmbedTextBatchResponse)
+async def embed_text_batch(request: EmbedTextBatchRequest) -> EmbedTextBatchResponse:
+    """Embed many texts in ONE provider call (OpenAI batch) -- the rate-safe
+    path for bulk embedding (e.g. the relation-vocabulary rollup). Avoids N
+    single /embed_text round-trips. Empty/blank texts are rejected so the
+    response stays index-aligned with the request.
+    """
+    with tracer.start_as_current_span("hermes.embed_text_batch") as span:
+        span.set_attribute("embedding.batch_size", len(request.texts))
+        if not request.texts:
+            return EmbedTextBatchResponse(embeddings=[])
+        if any(not t or not t.strip() for t in request.texts):
+            raise HTTPException(
+                status_code=400, detail="texts must not contain empty/blank entries"
+            )
+        try:
+            results = await generate_embeddings_batch(request.texts)
+            return EmbedTextBatchResponse(
+                embeddings=[
+                    EmbedTextResponse(
+                        embedding=r["embedding"],
+                        dimension=r["dimension"],
+                        model=r["model"],
+                        embedding_id=r["embedding_id"],
+                    )
+                    for r in results
+                ]
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(StatusCode.ERROR, str(e))
+            logger.error(f"Batch embedding error: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/src/hermes/services.py
+++ b/src/hermes/services.py
@@ -295,8 +295,14 @@ async def generate_embedding(text: str, model_name: str = "default") -> Dict[str
     }
 
 
-async def generate_embeddings_batch(texts: list[str]) -> list[Dict[str, Any]]:
+async def generate_embeddings_batch(
+    texts: list[str], model_name: str = "default"
+) -> list[Dict[str, Any]]:
     """Generate embeddings for multiple texts in a single API call.
+
+    ``model_name`` is accepted for parity with ``generate_embedding`` (the
+    configured provider is still authoritative; the field is not silently
+    dropped at the API boundary).
 
     Args:
         texts: List of texts to embed

--- a/tests/test_embed_batch_endpoint.py
+++ b/tests/test_embed_batch_endpoint.py
@@ -14,7 +14,7 @@ client = TestClient(m.app)
 
 
 def _fake_batch(n_dim=4):
-    async def fake(texts):
+    async def fake(texts, model_name="default", **kwargs):
         return [
             {
                 "embedding": [float(i)] * n_dim,
@@ -43,7 +43,7 @@ def test_batch_embeds_in_order(monkeypatch):
 def test_single_provider_call_for_the_whole_batch(monkeypatch):
     calls = {"n": 0}
 
-    async def fake(texts):
+    async def fake(texts, model_name="default", **kwargs):
         calls["n"] += 1
         return [
             {"embedding": [0.0], "dimension": 1, "model": "m", "embedding_id": "x"}
@@ -66,3 +66,28 @@ def test_blank_entry_rejected(monkeypatch):
     monkeypatch.setattr(m, "generate_embeddings_batch", _fake_batch())
     resp = client.post("/embed_text_batch", json={"texts": ["CARRIES", "  "]})
     assert resp.status_code == 400
+
+
+def test_oversize_batch_rejected(monkeypatch):
+    monkeypatch.setattr(m, "generate_embeddings_batch", _fake_batch())
+    resp = client.post(
+        "/embed_text_batch", json={"texts": ["x"] * (m.MAX_EMBED_BATCH + 1)}
+    )
+    assert resp.status_code == 400
+
+
+def test_model_passed_through(monkeypatch):
+    captured = {}
+
+    async def fake(texts, model_name="default", **kwargs):
+        captured["model_name"] = model_name
+        return [
+            {"embedding": [0.0], "dimension": 1, "model": "m", "embedding_id": "x"}
+            for _ in texts
+        ]
+
+    monkeypatch.setattr(m, "generate_embeddings_batch", fake)
+    client.post(
+        "/embed_text_batch", json={"texts": ["A", "B"], "model": "text-embedding-3-large"}
+    )
+    assert captured["model_name"] == "text-embedding-3-large"

--- a/tests/test_embed_batch_endpoint.py
+++ b/tests/test_embed_batch_endpoint.py
@@ -1,0 +1,68 @@
+"""Tests for POST /embed_text_batch — the rate-safe bulk embedding path.
+
+One provider call (OpenAI batch) for many texts instead of N single
+/embed_text round-trips. generate_embeddings_batch is monkeypatched; no
+live provider calls.
+"""
+
+from __future__ import annotations
+
+import hermes.main as m
+from fastapi.testclient import TestClient
+
+client = TestClient(m.app)
+
+
+def _fake_batch(n_dim=4):
+    async def fake(texts):
+        return [
+            {
+                "embedding": [float(i)] * n_dim,
+                "dimension": n_dim,
+                "model": "test-model",
+                "embedding_id": f"id-{i}",
+            }
+            for i, _ in enumerate(texts)
+        ]
+
+    return fake
+
+
+def test_batch_embeds_in_order(monkeypatch):
+    fake = _fake_batch()
+    monkeypatch.setattr(m, "generate_embeddings_batch", fake)
+    resp = client.post("/embed_text_batch", json={"texts": ["CARRIES", "HAULS", "DRAGS"]})
+    assert resp.status_code == 200
+    embeddings = resp.json()["embeddings"]
+    assert len(embeddings) == 3
+    assert embeddings[0]["embedding"] == [0.0, 0.0, 0.0, 0.0]
+    assert embeddings[1]["embedding"] == [1.0, 1.0, 1.0, 1.0]
+    assert embeddings[2]["dimension"] == 4
+
+
+def test_single_provider_call_for_the_whole_batch(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake(texts):
+        calls["n"] += 1
+        return [
+            {"embedding": [0.0], "dimension": 1, "model": "m", "embedding_id": "x"}
+            for _ in texts
+        ]
+
+    monkeypatch.setattr(m, "generate_embeddings_batch", fake)
+    client.post("/embed_text_batch", json={"texts": ["A", "B", "C", "D", "E"]})
+    assert calls["n"] == 1  # one batch call, not five
+
+
+def test_empty_texts_returns_empty(monkeypatch):
+    monkeypatch.setattr(m, "generate_embeddings_batch", _fake_batch())
+    resp = client.post("/embed_text_batch", json={"texts": []})
+    assert resp.status_code == 200
+    assert resp.json()["embeddings"] == []
+
+
+def test_blank_entry_rejected(monkeypatch):
+    monkeypatch.setattr(m, "generate_embeddings_batch", _fake_batch())
+    resp = client.post("/embed_text_batch", json={"texts": ["CARRIES", "  "]})
+    assert resp.status_code == 400


### PR DESCRIPTION
Program: c-daly/logos#557 · Supports the relation-vocabulary rollup (c-daly/sophia#192) and any bulk embedding.

## What

Exposes the **already-existing** `generate_embeddings_batch` (→ `provider.embed_batch`, one OpenAI call for N texts) as `POST /embed_text_batch`. The `/embed_text` endpoint is single-text only, so bulk consumers were forced into N single round-trips — which trip OpenAI rate limits under parallelism (hit live while triggering the rollup). One batch call avoids that.

- Request `{texts: [...], model?}` → `{embeddings: [{embedding, dimension, model, embedding_id}, ...]}`, index-aligned with input.
- Rejects blank entries (keeps alignment); empty list → empty.
- 4 tests incl. "one provider call for the whole batch, not N".

Also addresses the long-standing batch-embedding need (sophia#179 is the proposal-processor counterpart). Once deployed, the rollup's default wiring switches from looped `/embed_text` to one `/embed_text_batch` call.