### PR TITLE
H5 (#140): closed-vocabulary prompting in the combined extractor — stop relation sprawl at the source

### DIFF
--- a/src/hermes/combined_extractor.py
+++ b/src/hermes/combined_extractor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from typing import Any
 
@@ -102,10 +103,49 @@ class OpenAICombinedExtractor:
             "- Only extract relations clearly supported by the text\n"
             "- confidence is a float 0\u20131\n"
             "- If no entities or relations are found, return empty arrays\n\n"
-            "Return ONLY valid JSON, no other text."
         )
 
+        prompt += self._known_relations_section()
+        prompt += "Return ONLY valid JSON, no other text."
+
         return prompt
+
+    @staticmethod
+    def _known_relations_section() -> str:
+        """Closed-vocabulary clause for the RE step (H5, hermes#140).
+
+        Injects the current match-before-mint predicate vocabulary so the
+        model reuses an existing relation instead of minting a near-duplicate
+        -- the source-side lever for relation over-generation (the df=1
+        problem), validated by the NER/RE bake-off (logos-experiments#38).
+
+        Fail-soft: an empty or unavailable vocabulary yields no clause, so the
+        prompt degrades to the open form rather than raising. Bounded by
+        ``RE_VOCAB_CAP`` (default 150) because the live vocabulary can hold
+        thousands of surfaces; the cap keeps prompt tokens in check and, as
+        consolidation shrinks the vocabulary below it, the full clean set is
+        injected automatically.
+        """
+        try:
+            from hermes.predicate_resolver import get_predicate_vocabulary
+
+            known = get_predicate_vocabulary().known()
+        except Exception:
+            logger.warning("H5: predicate vocabulary unavailable; using open RE prompt")
+            return ""
+
+        if not known:
+            return ""
+
+        cap = int(os.getenv("RE_VOCAB_CAP", "150"))
+        vocab = sorted(known)[:cap]
+        return (
+            "## Known Relations\n"
+            "Prefer an existing predicate from this list when one fits the "
+            "meaning; only mint a NEW UPPER_SNAKE_CASE label when none of "
+            "these applies:\n"
+            f"{', '.join(vocab)}\n\n"
+        )
 
     async def extract_entities_and_relations(
         self, text: str

--- a/src/hermes/combined_extractor.py
+++ b/src/hermes/combined_extractor.py
@@ -137,7 +137,14 @@ class OpenAICombinedExtractor:
         if not known:
             return ""
 
-        cap = int(os.getenv("RE_VOCAB_CAP", "150"))
+        try:
+            cap = int(os.getenv("RE_VOCAB_CAP", "150"))
+        except ValueError:
+            logger.warning(
+                "H5: invalid RE_VOCAB_CAP=%r; using default 150",
+                os.getenv("RE_VOCAB_CAP"),
+            )
+            cap = 150
         vocab = sorted(known)[:cap]
         return (
             "## Known Relations\n"

--- a/tests/unit/test_combined_extractor.py
+++ b/tests/unit/test_combined_extractor.py
@@ -485,6 +485,10 @@ class TestClosedVocabPrompt:
         assert "LOCATED_IN" in prompt
         assert "PART_OF" in prompt
         assert "only mint a NEW" in prompt
+        # the clause must sit before the JSON-only sign-off, not after it
+        assert prompt.index("## Known Relations") < prompt.index(
+            "Return ONLY valid JSON"
+        )
 
     def test_clause_omitted_when_vocab_empty(self, monkeypatch):
         from hermes.combined_extractor import OpenAICombinedExtractor
@@ -504,6 +508,17 @@ class TestClosedVocabPrompt:
         # sorted, capped at 150 -> R000..R149 in, R150.. out
         assert "R149" in prompt
         assert "R150" not in prompt
+
+    def test_non_int_cap_falls_back_without_raising(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, {"LOCATED_IN", "PART_OF"})
+        monkeypatch.setenv("RE_VOCAB_CAP", "not-a-number")
+        # must not raise; falls back to the default cap and still injects
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        assert "## Known Relations" in prompt
+        assert "LOCATED_IN" in prompt
 
     def test_fail_soft_when_vocab_raises(self, monkeypatch):
         from hermes.combined_extractor import OpenAICombinedExtractor

--- a/tests/unit/test_combined_extractor.py
+++ b/tests/unit/test_combined_extractor.py
@@ -454,3 +454,69 @@ class TestSingleton:
         inst = get_combined_instance()
         assert isinstance(inst, OpenAICombinedExtractor)
         mod._combined_instance = None
+
+
+class TestClosedVocabPrompt:
+    """H5: closed-vocabulary clause injected into the combined RE prompt.
+
+    The clause reuses the live match-before-mint vocabulary
+    (``get_predicate_vocabulary().known()``) so the model prefers an existing
+    predicate over minting a near-duplicate -- the source-side df=1 lever.
+    """
+
+    @staticmethod
+    def _patch_vocab(monkeypatch, known):
+        class _StubVocab:
+            def known(self):
+                return set(known)
+
+        monkeypatch.setattr(
+            "hermes.predicate_resolver.get_predicate_vocabulary",
+            lambda: _StubVocab(),
+        )
+
+    def test_clause_injected_when_vocab_present(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, {"LOCATED_IN", "PART_OF"})
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        assert "## Known Relations" in prompt
+        assert "LOCATED_IN" in prompt
+        assert "PART_OF" in prompt
+        assert "only mint a NEW" in prompt
+
+    def test_clause_omitted_when_vocab_empty(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, set())
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        assert "## Known Relations" not in prompt
+
+    def test_cap_respected(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, {f"R{i:03d}" for i in range(200)})
+        monkeypatch.setenv("RE_VOCAB_CAP", "150")
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        # sorted, capped at 150 -> R000..R149 in, R150.. out
+        assert "R149" in prompt
+        assert "R150" not in prompt
+
+    def test_fail_soft_when_vocab_raises(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        class _Boom:
+            def known(self):
+                raise RuntimeError("redis down")
+
+        monkeypatch.setattr(
+            "hermes.predicate_resolver.get_predicate_vocabulary",
+            lambda: _Boom(),
+        )
+        # must not raise; falls back to the open prompt
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        assert "## Known Relations" not in prompt


### PR DESCRIPTION
## H5 — Closed-vocabulary prompting in the combined extractor

Closes #140. Part of epic #131. Source experiment: logos-experiments#38 (merged).

### What

Injects the live match-before-mint predicate vocabulary (`get_predicate_vocabulary().known()`) into the combined NER+RE system prompt with **reuse-don't-mint** pressure, so the model prefers an existing relation over minting a near-duplicate. New `_known_relations_section()` staticmethod, appended to the prompt just before the final "Return ONLY valid JSON" line.

### Why (empirical)

Validated by the NER/RE bake-off (logos-experiments#38, n=40, 10 arms):

- At a **fixed cheap model** (gpt-4o-mini), injecting a clean target vocabulary lifted relation **label-F1 0.171 → 0.439** (~2.6×), cut distinct predicates 34 → 26, and df=1 0.588 → 0.538 — at **no extra model cost**, no recall loss.
- A **bigger model on an open prompt made sprawl worse** (gpt-4o: 59 distinct, df=1 0.915). Spend is not the lever; the vocabulary is.

This complements H2 (match-before-mint canonicalizes *after* the fact); H5 reduces how many predicates get minted at all.

### Design

- **Vocab source:** the same `PredicateVocabulary` singleton H4 (`RelationRegistry`) seeds from `logos:ontology:relations` and keeps fresh on `proposal_processed`. No new plumbing.
- **Cap:** `RE_VOCAB_CAP` (default 150) — the live vocabulary can hold thousands of surfaces; the cap bounds prompt tokens. As consolidation shrinks the vocabulary below the cap, the full clean set is injected automatically (the benefit compounds with the rollup / W0.3b).
- **Fail-soft:** empty or unavailable vocabulary → no clause, prompt degrades to the open form, never raises.

### Tests

4 new (`TestClosedVocabPrompt`): clause injected when vocab present / omitted when empty / capped at `RE_VOCAB_CAP` / fail-soft when `known()` raises. Full combined-extractor suite green (16). ruff + black + mypy clean (src and tests).

### Base / stacking

Targets `feat/hermes137-relation-registry` (carries the H2 + H4 substrate this depends on), which is a clean descendant of `main`. Diff is the single H5 commit.

### Still open (tracked, not in this PR)

df=1 stays above the 0.25 gate at current scale — H5 is the source lever and is *necessary, not sufficient*; the gate also needs consolidation of the legacy tail (rollup sophia#192 / logos-experiments#34).
