### PR TITLE
Relation-vocabulary naming-driven-typing — extraction-time source fix (H1–H5, epic #131)

### DIFF
--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -122,7 +122,7 @@ def _fold_predicate_token(token: str) -> str:
         t = t[:-2]
     elif len(t) >= 4 and t.endswith("S") and not t.endswith(_PREDICATE_NO_S_STRIP):
         t = t[:-1]
-    if len(t) >= 5 and t.endswith("E"):
+    if len(t) >= 4 and t.endswith("E"):
         t = t[:-1]
     return t
 

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -63,6 +63,78 @@ _SINGULAR_SUFFIX_GUARD = ("ss", "is", "us")
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
+# --- predicate (descriptive-relation) canonicalization (hermes#130, H1) -----
+# The edge-axis analog of canonicalize(): folds morphological variants of a
+# descriptive relation onto one UPPER_SNAKE key so the open relation
+# vocabulary stops sprawling. Applied only to descriptive relations; the
+# reserved typing relations below are structural and never touched.
+_RESERVED_PREDICATES = frozenset({"IS_A", "INSTANCE_OF", "SUBTYPE_OF"})
+
+# Negation / modality markers: folding a negated predicate onto its positive
+# form flips meaning (DOES_NOT_REFER_TO -> REFERS_TO). If any token is a
+# marker, the predicate is normalized but NOT folded, so it can never collide
+# with its positive sibling.
+_POLARITY_MARKERS = frozenset(
+    {"NOT", "NO", "NEVER", "CANNOT", "CANT", "WITHOUT", "NON"}
+)
+
+# Tokens ending in these are not plurals/3sg -- never strip the trailing S
+# (ALIAS, BASIS, FOCUS, CHAOS, MASS). Same family as _SINGULAR_SUFFIX_GUARD,
+# uppercased for the predicate token space.
+_PREDICATE_NO_S_STRIP = ("SS", "US", "IS", "AS", "OS")
+
+_PREDICATE_SEP_RE = re.compile(r"[\s\-_]+")
+
+
+def _fold_predicate_token(token: str) -> str:
+    """Crude, deterministic, convergent stem for one UPPER-case token.
+
+    Strips one inflectional suffix (-ING / -IES / -ED / -S) then a trailing
+    stem -E, so base/3sg/past/gerund of a long-enough verb reach the SAME
+    key (ACQUIRE/ACQUIRES/ACQUIRED/ACQUIRING -> ACQUIR). Length guards keep
+    short tokens intact (RED, BED, IN); the -SS/-US/-IS/-AS/-OS guard keeps
+    non-plurals. The key is a stem, not necessarily prose -- convergence is
+    the contract (see test_canonical_predicate golden table).
+    """
+    t = token
+    if len(t) >= 6 and t.endswith("ING"):
+        t = t[:-3]
+    elif len(t) >= 5 and t.endswith("IES"):
+        t = t[:-3] + "Y"
+    elif len(t) >= 5 and t.endswith("ED"):
+        t = t[:-2]
+    elif len(t) >= 4 and t.endswith("S") and not t.endswith(_PREDICATE_NO_S_STRIP):
+        t = t[:-1]
+    if len(t) >= 5 and t.endswith("E"):
+        t = t[:-1]
+    return t
+
+
+def canonicalize_predicate(raw: str) -> str:
+    """Return the canonical UPPER_SNAKE key for a descriptive relation.
+
+    Idempotent. Empty / whitespace-only input returns "". Reserved typing
+    relations (IS_A / INSTANCE_OF / SUBTYPE_OF) are returned unchanged --
+    they are structural, never consolidated (callers also exclude them; this
+    is defense in depth). Predicates containing a polarity marker are
+    normalized (separators, case) but their content tokens are NOT folded,
+    so a negated relation can never collide with its positive form.
+    """
+    text = unicodedata.normalize("NFKC", raw).strip()
+    if not text:
+        return ""
+    tokens = [t for t in _PREDICATE_SEP_RE.split(text.upper()) if t]
+    if not tokens:
+        return ""
+
+    joined = "_".join(tokens)
+    if joined in _RESERVED_PREDICATES:
+        return joined
+    if any(t in _POLARITY_MARKERS for t in tokens):
+        return joined
+
+    return "_".join(_fold_predicate_token(t) for t in tokens)
+
 
 def singularize_word(word: str) -> str:
     """Singularize a single already-lowercased token, conservatively.

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -80,6 +80,23 @@ _PREDICATE_NO_S_STRIP = ("SS", "US", "IS", "AS", "OS")
 _PREDICATE_SEP_RE = re.compile(r"[\s\-_]+")
 
 
+def normalize_predicate_surface(raw: str) -> str:
+    """Readable UPPER_SNAKE surface form of a relation, no morphological fold.
+
+    NFKC -> strip -> unify separators (space/hyphen/underscore) -> upper.
+    This is the form STORED as the relation label; canonicalize_predicate()
+    derives the match KEY from the same normalization. Non-string / empty in
+    -> "" (the single chokepoint, so every predicate caller -- the resolver
+    and synonym pass included -- is robust to a non-string LLM value).
+    """
+    if not isinstance(raw, str):
+        return ""
+    text = unicodedata.normalize("NFKC", raw).strip()
+    if not text:
+        return ""
+    return "_".join(t for t in _PREDICATE_SEP_RE.split(text.upper()) if t)
+
+
 def _fold_predicate_token(token: str) -> str:
     """Crude, deterministic, convergent stem for one UPPER-case token.
 
@@ -125,16 +142,11 @@ def canonicalize_predicate(raw: str) -> str:
     them is therefore both correct AND lets negated variants converge
     (NOT_PRODUCES / NOT_PRODUCED -> NOT_PRODUC).
     """
-    if not isinstance(raw, str):
+    joined = normalize_predicate_surface(raw)
+    if not joined:
         return ""
-    text = unicodedata.normalize("NFKC", raw).strip()
-    if not text:
-        return ""
-    tokens = [t for t in _PREDICATE_SEP_RE.split(text.upper()) if t]
-    if not tokens:
-        return ""
+    tokens = joined.split("_")
 
-    joined = "_".join(tokens)
     if joined in RESERVED_PREDICATES:
         return joined
 

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -83,17 +83,23 @@ _PREDICATE_SEP_RE = re.compile(r"[\s\-_]+")
 def _fold_predicate_token(token: str) -> str:
     """Crude, deterministic, convergent stem for one UPPER-case token.
 
-    Strips one inflectional suffix (-ING / -IES / -ED / -S) then a trailing
-    stem -E, so base/3sg/past/gerund of a long-enough verb reach the SAME
-    key (ACQUIRE/ACQUIRES/ACQUIRED/ACQUIRING -> ACQUIR). Length guards keep
-    short tokens intact (RED, BED, IN); the -SS/-US/-IS/-AS/-OS guard keeps
-    non-plurals. The key is a stem, not necessarily prose -- convergence is
-    the contract (see test_canonical_predicate golden table).
+    Strips one inflectional suffix (-ING / -IES / -IED / -ED / -S) then a
+    trailing stem -E, so base/3sg/past/gerund of a long-enough verb reach
+    the SAME key (ACQUIRE/ACQUIRES/ACQUIRED/ACQUIRING -> ACQUIR). The -IED
+    past tense of -y verbs maps to -Y to match -IES (CARRY/CARRIES/CARRIED
+    -> CARRY), without which -y past tenses would diverge (review #134).
+    Length guards keep short tokens intact (RED, BED, IN); the
+    -SS/-US/-IS/-AS/-OS guard keeps non-plurals. The key is a stem, not
+    necessarily prose -- convergence is the contract (see golden table).
     """
     t = token
     if len(t) >= 6 and t.endswith("ING"):
         t = t[:-3]
     elif len(t) >= 5 and t.endswith("IES"):
+        t = t[:-3] + "Y"
+    elif len(t) >= 5 and t.endswith("IED"):
+        # past tense of a -y verb (carried/studied) -> the -y stem, so it
+        # converges with -IES/-Y rather than stranding a bare -I.
         t = t[:-3] + "Y"
     elif len(t) >= 5 and t.endswith("ED"):
         t = t[:-2]

--- a/src/hermes/canonical.py
+++ b/src/hermes/canonical.py
@@ -67,16 +67,10 @@ _WHITESPACE_RE = re.compile(r"\s+")
 # The edge-axis analog of canonicalize(): folds morphological variants of a
 # descriptive relation onto one UPPER_SNAKE key so the open relation
 # vocabulary stops sprawling. Applied only to descriptive relations; the
-# reserved typing relations below are structural and never touched.
-_RESERVED_PREDICATES = frozenset({"IS_A", "INSTANCE_OF", "SUBTYPE_OF"})
-
-# Negation / modality markers: folding a negated predicate onto its positive
-# form flips meaning (DOES_NOT_REFER_TO -> REFERS_TO). If any token is a
-# marker, the predicate is normalized but NOT folded, so it can never collide
-# with its positive sibling.
-_POLARITY_MARKERS = frozenset(
-    {"NOT", "NO", "NEVER", "CANNOT", "CANT", "WITHOUT", "NON"}
-)
+# reserved typing relations below are structural and never touched. Public
+# (consumed by predicate_resolver / relation_synonyms) -- the boundary is
+# explicit, not a private import.
+RESERVED_PREDICATES = frozenset({"IS_A", "INSTANCE_OF", "SUBTYPE_OF"})
 
 # Tokens ending in these are not plurals/3sg -- never strip the trailing S
 # (ALIAS, BASIS, FOCUS, CHAOS, MASS). Same family as _SINGULAR_SUFFIX_GUARD,
@@ -113,13 +107,20 @@ def _fold_predicate_token(token: str) -> str:
 def canonicalize_predicate(raw: str) -> str:
     """Return the canonical UPPER_SNAKE key for a descriptive relation.
 
-    Idempotent. Empty / whitespace-only input returns "". Reserved typing
-    relations (IS_A / INSTANCE_OF / SUBTYPE_OF) are returned unchanged --
-    they are structural, never consolidated (callers also exclude them; this
-    is defense in depth). Predicates containing a polarity marker are
-    normalized (separators, case) but their content tokens are NOT folded,
-    so a negated relation can never collide with its positive form.
+    Idempotent. Non-string / empty / whitespace-only input returns "".
+    Reserved typing relations (IS_A / INSTANCE_OF / SUBTYPE_OF) are returned
+    unchanged -- structural, never consolidated (callers exclude them too;
+    defense in depth).
+
+    Negation is safe WITHOUT special-casing: folding is per-token and never
+    removes a polarity token (NOT/NEVER/...), so a negated predicate always
+    keeps that token and can never collide with its positive form
+    (DOES_NOT_REFER_TO -> DOE_NOT_REFER_TO vs REFERS_TO -> REFER_TO). Folding
+    them is therefore both correct AND lets negated variants converge
+    (NOT_PRODUCES / NOT_PRODUCED -> NOT_PRODUC).
     """
+    if not isinstance(raw, str):
+        return ""
     text = unicodedata.normalize("NFKC", raw).strip()
     if not text:
         return ""
@@ -128,9 +129,7 @@ def canonicalize_predicate(raw: str) -> str:
         return ""
 
     joined = "_".join(tokens)
-    if joined in _RESERVED_PREDICATES:
-        return joined
-    if any(t in _POLARITY_MARKERS for t in tokens):
+    if joined in RESERVED_PREDICATES:
         return joined
 
     return "_".join(_fold_predicate_token(t) for t in tokens)

--- a/src/hermes/combined_extractor.py
+++ b/src/hermes/combined_extractor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from typing import Any
 
@@ -102,10 +103,49 @@ class OpenAICombinedExtractor:
             "- Only extract relations clearly supported by the text\n"
             "- confidence is a float 0\u20131\n"
             "- If no entities or relations are found, return empty arrays\n\n"
-            "Return ONLY valid JSON, no other text."
         )
 
+        prompt += self._known_relations_section()
+        prompt += "Return ONLY valid JSON, no other text."
+
         return prompt
+
+    @staticmethod
+    def _known_relations_section() -> str:
+        """Closed-vocabulary clause for the RE step (H5, hermes#140).
+
+        Injects the current match-before-mint predicate vocabulary so the
+        model reuses an existing relation instead of minting a near-duplicate
+        -- the source-side lever for relation over-generation (the df=1
+        problem), validated by the NER/RE bake-off (logos-experiments#38).
+
+        Fail-soft: an empty or unavailable vocabulary yields no clause, so the
+        prompt degrades to the open form rather than raising. Bounded by
+        ``RE_VOCAB_CAP`` (default 150) because the live vocabulary can hold
+        thousands of surfaces; the cap keeps prompt tokens in check and, as
+        consolidation shrinks the vocabulary below it, the full clean set is
+        injected automatically.
+        """
+        try:
+            from hermes.predicate_resolver import get_predicate_vocabulary
+
+            known = get_predicate_vocabulary().known()
+        except Exception:
+            logger.warning("H5: predicate vocabulary unavailable; using open RE prompt")
+            return ""
+
+        if not known:
+            return ""
+
+        cap = int(os.getenv("RE_VOCAB_CAP", "150"))
+        vocab = sorted(known)[:cap]
+        return (
+            "## Known Relations\n"
+            "Prefer an existing predicate from this list when one fits the "
+            "meaning; only mint a NEW UPPER_SNAKE_CASE label when none of "
+            "these applies:\n"
+            f"{', '.join(vocab)}\n\n"
+        )
 
     async def extract_entities_and_relations(
         self, text: str

--- a/src/hermes/combined_extractor.py
+++ b/src/hermes/combined_extractor.py
@@ -138,7 +138,7 @@ class OpenAICombinedExtractor:
             return ""
 
         try:
-            cap = int(os.getenv("RE_VOCAB_CAP", "150"))
+            cap = max(0, int(os.getenv("RE_VOCAB_CAP", "150")))
         except ValueError:
             logger.warning(
                 "H5: invalid RE_VOCAB_CAP=%r; using default 150",
@@ -146,6 +146,8 @@ class OpenAICombinedExtractor:
             )
             cap = 150
         vocab = sorted(known)[:cap]
+        if not vocab:  # cap sliced everything away -> open prompt, not an empty clause
+            return ""
         return (
             "## Known Relations\n"
             "Prefer an existing predicate from this list when one fits the "

--- a/src/hermes/combined_extractor.py
+++ b/src/hermes/combined_extractor.py
@@ -137,7 +137,14 @@ class OpenAICombinedExtractor:
         if not known:
             return ""
 
-        cap = int(os.getenv("RE_VOCAB_CAP", "150"))
+        try:
+            cap = int(os.getenv("RE_VOCAB_CAP", "150"))
+        except ValueError:
+            logger.warning(
+                "H5: invalid RE_VOCAB_CAP=%r; using default 150",
+                os.getenv("RE_VOCAB_CAP"),
+            )
+            cap = 150
         vocab = sorted(known)[:cap]
         return (
             "## Known Relations\n"

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -288,6 +288,7 @@ _type_registry_redis_client = None
 _relation_registry = None
 _relation_registry_event_bus = None
 _relation_registry_listener = None
+_relation_registry_redis_client = None
 
 
 @asynccontextmanager
@@ -345,29 +346,6 @@ async def lifespan(app: FastAPI):  # type: ignore
         )
         _type_registry_listener.start()
         logger.info("TypeRegistry subscribed to ontology changes")
-
-        # Seed the match-before-mint predicate vocabulary from the same
-        # Sophia sync (sophia#190 -> hermes#137). Own EventBus/listener
-        # because redis-py keeps one handler per channel; Redis pub/sub
-        # broadcasts the event to both.
-        from hermes.predicate_resolver import get_predicate_vocabulary
-        from hermes.relation_registry import RelationRegistry
-
-        _relation_registry = RelationRegistry(
-            _type_registry_redis_client, get_predicate_vocabulary()
-        )
-        _relation_registry_event_bus = EventBus(_redis_config)
-        _relation_registry_event_bus.subscribe(
-            "logos:sophia:proposal_processed",
-            _relation_registry.on_proposal_processed,
-        )
-        _relation_registry_listener = threading.Thread(
-            target=_relation_registry_event_bus.listen,
-            daemon=True,
-            name="relation-registry-listener",
-        )
-        _relation_registry_listener.start()
-        logger.info("RelationRegistry seeded and subscribed to ontology changes")
     except Exception:
         logger.warning(
             "TypeRegistry unavailable — ontology type sync disabled",
@@ -382,6 +360,56 @@ async def lifespan(app: FastAPI):  # type: ignore
         _type_registry = None
         _type_registry_event_bus = None
         _type_registry_listener = None
+
+    # Seed the match-before-mint predicate vocabulary from the same Sophia
+    # sync (sophia#190 -> hermes#137). INDEPENDENT fail-soft block: a failure
+    # here must not disable the already-running TypeRegistry (and vice versa),
+    # and its own thread is cleaned up on failure. Own redis client +
+    # EventBus/listener because redis-py keeps one handler per channel; Redis
+    # pub/sub broadcasts the event to both.
+    global _relation_registry_redis_client
+    try:
+        import redis as _redis_mod
+
+        from hermes.predicate_resolver import get_predicate_vocabulary
+        from hermes.relation_registry import RelationRegistry
+        from logos_events import EventBus  # type: ignore[import-not-found]
+
+        _relation_registry_redis_client = _redis_mod.from_url(RedisConfig().url)
+        _relation_registry = RelationRegistry(
+            _relation_registry_redis_client, get_predicate_vocabulary()
+        )
+        _relation_registry_event_bus = EventBus(RedisConfig())
+        _relation_registry_event_bus.subscribe(
+            "logos:sophia:proposal_processed",
+            _relation_registry.on_proposal_processed,
+        )
+        _relation_registry_listener = threading.Thread(
+            target=_relation_registry_event_bus.listen,
+            daemon=True,
+            name="relation-registry-listener",
+        )
+        _relation_registry_listener.start()
+        logger.info("RelationRegistry seeded and subscribed to ontology changes")
+    except Exception:
+        logger.warning(
+            "RelationRegistry unavailable — predicate vocabulary sync disabled",
+            exc_info=True,
+        )
+        if _relation_registry_event_bus is not None:
+            try:
+                _relation_registry_event_bus.stop()
+            except Exception:
+                pass
+        if _relation_registry_redis_client is not None:
+            try:
+                _relation_registry_redis_client.close()
+            except Exception:
+                pass
+            _relation_registry_redis_client = None
+        _relation_registry = None
+        _relation_registry_event_bus = None
+        _relation_registry_listener = None
     logger.info("Hermes API startup complete")
     yield
     # Shutdown
@@ -404,6 +432,11 @@ async def lifespan(app: FastAPI):  # type: ignore
             logger.warning("RelationRegistry listener thread did not stop within 5s")
         else:
             logger.info("RelationRegistry event listener stopped")
+    if _relation_registry_redis_client is not None:
+        try:
+            _relation_registry_redis_client.close()
+        except Exception:
+            pass
     if _type_registry_redis_client is not None:
         _type_registry_redis_client.close()
     milvus_client.disconnect_milvus()

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1947,7 +1947,10 @@ async def relation_synonyms(
             messages=messages,
             temperature=0.0,
             max_tokens=1024,
-            metadata={"scenario": "relation_synonyms", "request_id": request.request_id},
+            metadata={
+                "scenario": "relation_synonyms",
+                "request_id": request.request_id,
+            },
         )
     except LLMProviderNotConfiguredError as exc:
         logger.error("relation_synonyms: LLM provider not configured: %s", exc)

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -423,7 +423,7 @@ async def lifespan(app: FastAPI):  # type: ignore
             logger.warning("TypeRegistry listener thread did not stop within 5s")
         else:
             logger.info("TypeRegistry event listener stopped")
-    # Stop RelationRegistry event listener (shares the redis client closed above)
+    # Stop RelationRegistry event listener (EventBus closes its own connection via .stop())
     if _relation_registry_event_bus is not None:
         _relation_registry_event_bus.stop()
     if _relation_registry_listener is not None:
@@ -1977,7 +1977,7 @@ async def relation_synonyms(
         request_id=request.request_id,
         groups=[
             RelationSynonymGroup(
-                canonical=g.canonical, members=g.members, confidence=g.confidence
+                canonical=g.canonical, members=list(g.members), confidence=g.confidence
             )
             for g in groups
         ],

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1892,7 +1892,13 @@ async def relation_synonyms(
     choices = result.get("choices") or []
     if not choices:
         raise HTTPException(status_code=502, detail="LLM returned no choices")
-    content = choices[0]["message"]["content"]
+    try:
+        content = choices[0]["message"]["content"]
+    except (KeyError, TypeError, IndexError) as exc:
+        logger.error("relation_synonyms: malformed LLM response shape: %s", exc)
+        raise HTTPException(
+            status_code=502, detail="LLM returned a malformed response"
+        ) from exc
 
     groups = parse_synonym_response(content, request.predicates)
     return RelationSynonymsResponse(

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -285,6 +285,9 @@ _type_registry = None
 _type_registry_event_bus = None
 _type_registry_listener = None
 _type_registry_redis_client = None
+_relation_registry = None
+_relation_registry_event_bus = None
+_relation_registry_listener = None
 
 
 @asynccontextmanager
@@ -314,6 +317,7 @@ async def lifespan(app: FastAPI):  # type: ignore
     milvus_client.initialize_milvus()
     # Initialize TypeRegistry for ontology type sync
     global _type_registry, _type_registry_event_bus, _type_registry_listener, _type_registry_redis_client
+    global _relation_registry, _relation_registry_event_bus, _relation_registry_listener
     try:
         from hermes.type_registry import TypeRegistry
         import redis
@@ -341,6 +345,29 @@ async def lifespan(app: FastAPI):  # type: ignore
         )
         _type_registry_listener.start()
         logger.info("TypeRegistry subscribed to ontology changes")
+
+        # Seed the match-before-mint predicate vocabulary from the same
+        # Sophia sync (sophia#190 -> hermes#137). Own EventBus/listener
+        # because redis-py keeps one handler per channel; Redis pub/sub
+        # broadcasts the event to both.
+        from hermes.predicate_resolver import get_predicate_vocabulary
+        from hermes.relation_registry import RelationRegistry
+
+        _relation_registry = RelationRegistry(
+            _type_registry_redis_client, get_predicate_vocabulary()
+        )
+        _relation_registry_event_bus = EventBus(_redis_config)
+        _relation_registry_event_bus.subscribe(
+            "logos:sophia:proposal_processed",
+            _relation_registry.on_proposal_processed,
+        )
+        _relation_registry_listener = threading.Thread(
+            target=_relation_registry_event_bus.listen,
+            daemon=True,
+            name="relation-registry-listener",
+        )
+        _relation_registry_listener.start()
+        logger.info("RelationRegistry seeded and subscribed to ontology changes")
     except Exception:
         logger.warning(
             "TypeRegistry unavailable — ontology type sync disabled",
@@ -368,6 +395,15 @@ async def lifespan(app: FastAPI):  # type: ignore
             logger.warning("TypeRegistry listener thread did not stop within 5s")
         else:
             logger.info("TypeRegistry event listener stopped")
+    # Stop RelationRegistry event listener (shares the redis client closed above)
+    if _relation_registry_event_bus is not None:
+        _relation_registry_event_bus.stop()
+    if _relation_registry_listener is not None:
+        _relation_registry_listener.join(timeout=5)
+        if _relation_registry_listener.is_alive():
+            logger.warning("RelationRegistry listener thread did not stop within 5s")
+        else:
+            logger.info("RelationRegistry event listener stopped")
     if _type_registry_redis_client is not None:
         _type_registry_redis_client.close()
     milvus_client.disconnect_milvus()

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1823,6 +1823,89 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
     )
 
 
+# ---------------------------------------------------------------------
+# Relation synonym-collapse: POST /relation-synonyms (hermes#133, H3)
+#
+# The relation-axis analog of /name-cluster: the LLM groups DESCRIPTIVE
+# relation synonyms (HAULS/DRAGS/CARRIES -> CARRIES). Server-side
+# validation (hermes.relation_synonyms) is fail-closed and enforces the
+# epic #131 hard constraint -- no group may contain a reserved typing
+# relation (IS_A/INSTANCE_OF/SUBTYPE_OF). The response is a PROPOSAL;
+# callers apply it through the existing propose->assert / review path.
+# ---------------------------------------------------------------------
+class RelationSynonymsRequest(BaseModel):
+    predicates: list[str] = Field(..., description="Descriptive relation labels.")
+    context: str | None = Field(
+        default=None, description="Optional domain context for disambiguation."
+    )
+    request_id: str | None = None
+
+
+class RelationSynonymGroup(BaseModel):
+    canonical: str
+    members: list[str]
+    confidence: float
+
+
+class RelationSynonymsResponse(BaseModel):
+    request_id: str | None = None
+    groups: list[RelationSynonymGroup]
+
+
+@app.post("/relation-synonyms", response_model=RelationSynonymsResponse)
+async def relation_synonyms(
+    request: RelationSynonymsRequest,
+) -> RelationSynonymsResponse:
+    """Propose descriptive-relation synonym groups (the relation naming pass).
+
+    The LLM is a codec: it proposes groupings + a canonical name from the
+    members; placement/assertion happen elsewhere. Reserved typing relations
+    are filtered from the prompt AND rejected in validation -- they are never
+    consolidated. Empty/insufficient input returns no groups (200, not 4xx):
+    "nothing to collapse" is a valid answer.
+    """
+    from hermes.relation_synonyms import (
+        build_synonym_messages,
+        parse_synonym_response,
+    )
+
+    if len([p for p in request.predicates if p and p.strip()]) < 2:
+        return RelationSynonymsResponse(request_id=request.request_id, groups=[])
+
+    messages = build_synonym_messages(request.predicates, context=request.context)
+    try:
+        result = await generate_completion(
+            messages=messages,
+            temperature=0.0,
+            max_tokens=1024,
+            metadata={"scenario": "relation_synonyms", "request_id": request.request_id},
+        )
+    except LLMProviderNotConfiguredError as exc:
+        logger.error("relation_synonyms: LLM provider not configured: %s", exc)
+        raise HTTPException(
+            status_code=503, detail="LLM provider not configured"
+        ) from exc
+    except LLMProviderError as exc:
+        logger.error("relation_synonyms: LLM provider error: %s", exc)
+        raise HTTPException(status_code=502, detail="LLM provider error") from exc
+
+    choices = result.get("choices") or []
+    if not choices:
+        raise HTTPException(status_code=502, detail="LLM returned no choices")
+    content = choices[0]["message"]["content"]
+
+    groups = parse_synonym_response(content, request.predicates)
+    return RelationSynonymsResponse(
+        request_id=request.request_id,
+        groups=[
+            RelationSynonymGroup(
+                canonical=g.canonical, members=g.members, confidence=g.confidence
+            )
+            for g in groups
+        ],
+    )
+
+
 class NameRelationshipRequest(BaseModel):
     source_name: str = Field(..., description="Source node name")
     target_name: str = Field(..., description="Target node name")

--- a/src/hermes/predicate_resolver.py
+++ b/src/hermes/predicate_resolver.py
@@ -1,0 +1,130 @@
+"""Catalog-aware prefer-existing predicate resolution (hermes#132, H2).
+
+Match-before-mint for descriptive relations -- the edge-axis analog of
+node-side rollup match-before-mint. A candidate relation label is checked
+against the known vocabulary by its H1 canonical key (hermes.canonical):
+
+  * reserved typing relations (IS_A / INSTANCE_OF / SUBTYPE_OF) pass through
+    untouched -- they are structural, never consolidated;
+  * if the candidate's canonical key matches a known predicate, REUSE that
+    predicate's existing surface form (matched);
+  * otherwise MINT: store the candidate's readable surface form (not the
+    stem) as a new predicate (minted).
+
+The canonical key does the matching; the stored label is a real surface
+form, so the graph stays readable while the vocabulary stops sprawling.
+Every resolution carries provenance (status + raw + canonical) for audit.
+
+`resolve_predicate(raw, index)` is pure (testable). `PredicateVocabulary`
+is the stateful wrapper extraction uses: mints accumulate in-process, and
+`seed()` is the injection point for the persisted vocabulary (the
+ontology-backed source / hermes#122 batch surface). H3 (#133) will add a
+synonym-similarity step between match and mint.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+from hermes.canonical import (
+    RESERVED_PREDICATES,
+    canonicalize_predicate,
+    normalize_predicate_surface,
+)
+
+
+@dataclass(frozen=True)
+class Resolution:
+    relation: str  # the chosen stored label ("" if dropped)
+    status: Literal["matched", "minted", "reserved", "empty"]
+    canonical: str  # the H1 match key
+    raw: str  # the original surface as received
+
+
+def index_vocabulary(predicates: Iterable[str]) -> dict[str, str]:
+    """canonical key -> representative surface, over known descriptive
+    predicates. Reserved typing relations are excluded. On a canonical
+    collision the lexicographically-min surface wins (deterministic)."""
+    index: dict[str, str] = {}
+    for p in predicates:
+        surface = normalize_predicate_surface(p)
+        if not surface or surface in RESERVED_PREDICATES:
+            continue
+        key = canonicalize_predicate(surface)
+        existing = index.get(key)
+        if existing is None or surface < existing:
+            index[key] = surface
+    return index
+
+
+def resolve_predicate(raw: str, index: dict[str, str]) -> Resolution:
+    """Resolve one candidate predicate against a fixed vocabulary index.
+
+    Pure: does not mutate `index`. See module docstring for the policy.
+    """
+    surface = normalize_predicate_surface(raw)
+    if not surface:
+        return Resolution("", "empty", "", raw)
+    if surface in RESERVED_PREDICATES:
+        return Resolution(surface, "reserved", surface, raw)
+    key = canonicalize_predicate(surface)
+    existing = index.get(key)
+    if existing is not None:
+        return Resolution(existing, "matched", key, raw)
+    return Resolution(surface, "minted", key, raw)
+
+
+class PredicateVocabulary:
+    """Stateful, thread-safe match-before-mint vocabulary.
+
+    Resolving an unknown descriptive predicate mints it (the surface is
+    added to the index); later inflected variants in the same process then
+    match it. `seed()` injects a persisted vocabulary up front.
+    """
+
+    def __init__(self) -> None:
+        self._index: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def seed(self, predicates: Iterable[str]) -> None:
+        # Normalize/canonicalize outside the lock (CPU-bound); hold the lock
+        # only for the dict merge, to avoid contending with resolve().
+        incoming = index_vocabulary(predicates)
+        with self._lock:
+            for key, surface in incoming.items():
+                # seed never overwrites an existing mint for the same key
+                self._index.setdefault(key, surface)
+
+    def resolve(self, raw: str) -> Resolution:
+        surface = normalize_predicate_surface(raw)
+        if not surface:
+            return Resolution("", "empty", "", raw)
+        if surface in RESERVED_PREDICATES:
+            return Resolution(surface, "reserved", surface, raw)
+        key = canonicalize_predicate(surface)
+        with self._lock:
+            existing = self._index.get(key)
+            if existing is not None:
+                return Resolution(existing, "matched", key, raw)
+            self._index[key] = surface
+            return Resolution(surface, "minted", key, raw)
+
+    def known(self) -> set[str]:
+        with self._lock:
+            return set(self._index.values())
+
+
+# Process-local singleton used by the extractors. Eagerly initialized (the
+# object is lightweight and has no import-time side effects) so there is no
+# lazy check-then-set race if it is reached from a worker thread before
+# relation_extractor's import-time seed runs. Seed it from the persisted
+# vocabulary at startup (the ontology-injection hook) so match-before-mint
+# spans processes; until then it accumulates within a process.
+_VOCABULARY = PredicateVocabulary()
+
+
+def get_predicate_vocabulary() -> PredicateVocabulary:
+    return _VOCABULARY

--- a/src/hermes/relation_extractor.py
+++ b/src/hermes/relation_extractor.py
@@ -17,6 +17,8 @@ from typing import Any, Protocol, runtime_checkable
 
 from logos_config import get_env_value
 
+from hermes.predicate_resolver import get_predicate_vocabulary
+
 logger = logging.getLogger(__name__)
 
 # Map common verb/prep patterns to canonical relation labels.
@@ -47,6 +49,12 @@ _SYMMETRIC_RELATIONS: frozenset[str] = frozenset(
         "COLLABORATES_WITH",
     }
 )
+
+# The curated relation labels above are already-canonical descriptive
+# relations; seed them into the match-before-mint vocabulary so #132 reuses
+# them rather than minting near-variants. This subsumes _VERB_TO_RELATION
+# into the resolver instead of running a parallel mechanism (#132).
+get_predicate_vocabulary().seed(set(_VERB_TO_RELATION.values()) | _SYMMETRIC_RELATIONS)
 
 
 @runtime_checkable
@@ -172,6 +180,14 @@ class SpacyRelationExtractor:
             raw_phrase = " ".join(tok.text for tok in doc[src_ent.start : tgt_ent.end])
             relation = preps[0].upper() if preps else "RELATED_TO"
 
+        # Catalog-aware prefer-existing predicate (#132): reuse a known
+        # relation by canonical key before minting; symmetry is read off the
+        # resolved label. Drop empties.
+        resolution = get_predicate_vocabulary().resolve(relation)
+        if resolution.status == "empty":
+            return None
+        relation = resolution.relation
+
         bidirectional = relation in _SYMMETRIC_RELATIONS
         # Simple heuristic confidence: verbs are more reliable than preps.
         confidence = 0.8 if verbs else 0.5
@@ -184,6 +200,11 @@ class SpacyRelationExtractor:
             "bidirectional": bidirectional,
             "properties": {
                 "raw_phrase": raw_phrase,
+                "predicate": {
+                    "status": resolution.status,
+                    "raw": resolution.raw,
+                    "canonical": resolution.canonical,
+                },
             },
         }
 
@@ -286,8 +307,13 @@ class OpenAIRelationExtractor:
             if src not in entity_names or tgt not in entity_names:
                 continue
 
-            # Normalize relation label
-            relation = relation.upper().replace(" ", "_")
+            # Catalog-aware prefer-existing predicate (#132): match a known
+            # relation by canonical key before minting a new one; the stored
+            # label is a readable surface form. Drop empties.
+            resolution = get_predicate_vocabulary().resolve(relation)
+            if resolution.status == "empty":
+                continue
+            relation = resolution.relation
 
             key = (src, tgt, relation)
             if key in seen:
@@ -306,7 +332,13 @@ class OpenAIRelationExtractor:
                     "relation": relation,
                     "confidence": confidence,
                     "bidirectional": bool(rel.get("bidirectional", False)),
-                    "properties": {},
+                    "properties": {
+                        "predicate": {
+                            "status": resolution.status,
+                            "raw": resolution.raw,
+                            "canonical": resolution.canonical,
+                        }
+                    },
                 }
             )
 

--- a/src/hermes/relation_registry.py
+++ b/src/hermes/relation_registry.py
@@ -61,10 +61,15 @@ class RelationRegistry:
                 type(data).__name__,
             )
             return
-        # seed() filters reserved typing relations and dedups by canonical key
+        # seed() filters reserved typing relations and dedups by canonical
+        # key, so the number actually added is <= the raw snapshot size.
+        before = len(self._vocabulary.known())
         self._vocabulary.seed(data.keys())
+        added = len(self._vocabulary.known()) - before
         logger.info(
-            "RelationRegistry seeded %d relations from Redis", len(data)
+            "RelationRegistry: +%d relations from a %d-entry snapshot",
+            added,
+            len(data),
         )
 
     def on_proposal_processed(self, event: dict) -> None:

--- a/src/hermes/relation_registry.py
+++ b/src/hermes/relation_registry.py
@@ -1,0 +1,73 @@
+"""RelationRegistry — seeds the predicate vocabulary from Redis + pub/sub.
+
+The edge-axis analog of TypeRegistry (hermes#137, H4). Reads the
+descriptive-relation snapshot Sophia publishes to ``logos:ontology:relations``
+(sophia#190) and seeds the match-before-mint ``PredicateVocabulary`` on boot,
+re-seeding on every ``logos:sophia:proposal_processed`` event so newly-minted
+relations propagate to every Hermes worker. Redis is the shared substrate, so
+this makes match-before-mint cross-process; the EventBus reload keeps it
+fresh.
+
+Unlike TypeRegistry this holds no state of its own — the vocabulary is the
+store. Seeding is additive (``PredicateVocabulary.seed`` uses setdefault), so
+a reload never drops a predicate minted in-process that has not yet
+round-tripped back through Sophia's next snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from hermes.predicate_resolver import PredicateVocabulary
+
+logger = logging.getLogger(__name__)
+
+
+class RelationRegistry:
+    """Syncs the descriptive-relation vocabulary from Redis into the
+    match-before-mint vocabulary."""
+
+    REDIS_KEY = "logos:ontology:relations"
+
+    def __init__(self, redis_client: Any, vocabulary: PredicateVocabulary) -> None:
+        self._redis = redis_client
+        self._vocabulary = vocabulary
+        self._load_and_seed()
+
+    def _load_and_seed(self) -> None:
+        """Read the relation snapshot from Redis and seed the vocabulary.
+
+        Fail-soft: a missing key, malformed snapshot, or Redis error leaves
+        the vocabulary as-is (extraction still works with whatever it has).
+        """
+        try:
+            raw = self._redis.get(self.REDIS_KEY)
+        except Exception:
+            logger.exception("RelationRegistry: failed to read %s", self.REDIS_KEY)
+            return
+        if raw is None:
+            logger.info("RelationRegistry: no relation snapshot in Redis")
+            return
+        try:
+            data = json.loads(raw)
+        except (TypeError, json.JSONDecodeError):
+            logger.exception("RelationRegistry: malformed relation snapshot")
+            return
+        if not isinstance(data, dict):
+            logger.error(
+                "RelationRegistry: invalid snapshot type %s (expected dict)",
+                type(data).__name__,
+            )
+            return
+        # seed() filters reserved typing relations and dedups by canonical key
+        self._vocabulary.seed(data.keys())
+        logger.info(
+            "RelationRegistry seeded %d relations from Redis", len(data)
+        )
+
+    def on_proposal_processed(self, event: dict) -> None:
+        """EventBus callback — re-read the snapshot and re-seed (additive)."""
+        logger.info("RelationRegistry: proposal_processed event, reloading relations")
+        self._load_and_seed()

--- a/src/hermes/relation_synonyms.py
+++ b/src/hermes/relation_synonyms.py
@@ -73,8 +73,7 @@ def build_synonym_messages(
     candidates = [
         p
         for p in predicates
-        if (surf := normalize_predicate_surface(p))
-        and surf not in RESERVED_PREDICATES
+        if (surf := normalize_predicate_surface(p)) and surf not in RESERVED_PREDICATES
     ]
     ctx = f"Domain context: {context}\n\n" if context else ""
     user = f"{ctx}Candidates: {', '.join(candidates)}\n\nGroup the synonyms."
@@ -88,20 +87,20 @@ def _coerce_json(content: str) -> dict | None:
     if not isinstance(content, str):
         return None
     try:
-        return json.loads(content)
+        parsed = json.loads(content)
+        return parsed if isinstance(parsed, dict) else None
     except json.JSONDecodeError:
         match = re.search(r"```(?:json)?\s*(.*?)```", content, re.DOTALL)
         if match:
             try:
-                return json.loads(match.group(1))
+                parsed = json.loads(match.group(1))
+                return parsed if isinstance(parsed, dict) else None
             except json.JSONDecodeError:
                 return None
     return None
 
 
-def parse_synonym_response(
-    content: str, candidates: list[str]
-) -> list[SynonymGroup]:
+def parse_synonym_response(content: str, candidates: list[str]) -> list[SynonymGroup]:
     """Validate the LLM response into safe synonym groups. Fail closed:
     anything malformed or rule-violating drops the offending group."""
     data = _coerce_json(content)

--- a/src/hermes/relation_synonyms.py
+++ b/src/hermes/relation_synonyms.py
@@ -1,0 +1,165 @@
+"""Descriptive-relation synonym-collapse pass (hermes#133, H3).
+
+The relation-axis analog of /name-cluster: the LLM detects DESCRIPTIVE
+relation synonyms (HAULS/DRAGS/CARRIES -> CARRIES) -- the linguistic-
+boundary work the H1 canonicalizer structurally cannot do. The LLM is a
+codec: it proposes synonym groupings + a canonical name; it does not decide
+placement or touch structure. This module owns the contract + fail-closed
+server-side validation only. The endpoint (main.py) calls the LLM; the
+graph is never mutated here -- output is a PROPOSAL routed through the
+existing propose->assert / review path.
+
+Hard rules (epic #131, enforced here, not trusted to the model):
+  * no group may contain a reserved typing relation (IS_A/INSTANCE_OF/
+    SUBTYPE_OF) -- those are structural and off-limits to consolidation;
+  * members must be among the submitted candidates (no hallucinations);
+  * members are deduped by H1 canonical key; a group that collapses to one
+    distinct relation is not a synonym group;
+  * the canonical label is an H1-normalized surface and must be a real
+    member.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+
+from hermes.canonical import (
+    _RESERVED_PREDICATES,
+    canonicalize_predicate,
+    normalize_predicate_surface,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SynonymGroup:
+    canonical: str
+    members: list[str]
+    confidence: float
+
+
+_SYSTEM_PROMPT = (
+    "You are a relation-vocabulary synonym detector for the LOGOS knowledge "
+    "graph. Given a list of DESCRIPTIVE relation labels, group together the "
+    "ones that mean the SAME relation (e.g. HAULS, DRAGS, CARRIES) and give "
+    "each group one canonical UPPER_SNAKE_CASE label chosen from its "
+    "members.\n\n"
+    "Hard rules:\n"
+    "- NEVER group the structural typing relations IS_A, INSTANCE_OF, or "
+    "SUBTYPE_OF with anything -- they are off-limits and must not appear in "
+    "any group.\n"
+    "- Only group labels that are TRUE synonyms (interchangeable in meaning "
+    "and direction); when unsure, leave a label out.\n"
+    "- Never invent labels: every member must come from the provided list.\n"
+    "- A group needs at least two distinct relations; do not emit singletons.\n\n"
+    'Return ONLY valid JSON: {"groups": [{"canonical": "...", "members": '
+    '["...", "..."], "confidence": 0.0-1.0}]}.'
+)
+
+
+def build_synonym_messages(
+    predicates: list[str], context: str | None = None
+) -> list[dict[str, str]]:
+    """Build the chat messages for the synonym pass.
+
+    Reserved typing relations are filtered out of the candidate list before
+    the model ever sees them (defense in depth -- the prompt also forbids
+    grouping them).
+    """
+    candidates = [
+        p
+        for p in predicates
+        if normalize_predicate_surface(p) not in _RESERVED_PREDICATES
+        and normalize_predicate_surface(p)
+    ]
+    ctx = f"Domain context: {context}\n\n" if context else ""
+    user = f"{ctx}Candidates: {', '.join(candidates)}\n\nGroup the synonyms."
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user},
+    ]
+
+
+def _coerce_json(content: str) -> dict | None:
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        match = re.search(r"```(?:json)?\s*(.*?)```", content, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(1))
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def parse_synonym_response(
+    content: str, candidates: list[str]
+) -> list[SynonymGroup]:
+    """Validate the LLM response into safe synonym groups. Fail closed:
+    anything malformed or rule-violating drops the offending group."""
+    data = _coerce_json(content)
+    if not isinstance(data, dict):
+        return []
+    raw_groups = data.get("groups")
+    if not isinstance(raw_groups, list):
+        return []
+
+    # candidate surfaces by canonical key (what the members may reference)
+    allowed_surface = {
+        normalize_predicate_surface(c)
+        for c in candidates
+        if normalize_predicate_surface(c)
+    }
+
+    out: list[SynonymGroup] = []
+    for grp in raw_groups:
+        if not isinstance(grp, dict):
+            continue
+        raw_members = grp.get("members")
+        if not isinstance(raw_members, list):
+            continue
+
+        members_surface: list[str] = []
+        seen_canon: set[str] = set()
+        bad = False
+        for m in raw_members:
+            if not isinstance(m, str):
+                bad = True
+                break
+            surface = normalize_predicate_surface(m)
+            if not surface or surface not in allowed_surface:
+                bad = True  # hallucinated or empty member
+                break
+            if surface in _RESERVED_PREDICATES:
+                bad = True  # reserved relation anywhere kills the group
+                break
+            canon = canonicalize_predicate(surface)
+            if canon not in seen_canon:
+                seen_canon.add(canon)
+                members_surface.append(surface)
+        if bad:
+            continue
+        if len(seen_canon) < 2:
+            continue  # not a real collapse
+
+        # canonical label: the LLM's pick if it is a real member, else the
+        # first member (deterministic) -- never a hallucinated/reserved name
+        proposed = normalize_predicate_surface(str(grp.get("canonical", "")))
+        canonical = (
+            proposed
+            if proposed in members_surface and proposed not in _RESERVED_PREDICATES
+            else members_surface[0]
+        )
+
+        confidence = grp.get("confidence", 0.7)
+        if not isinstance(confidence, (int, float)):
+            confidence = 0.7
+        confidence = max(0.0, min(1.0, float(confidence)))
+
+        out.append(SynonymGroup(canonical, members_surface, confidence))
+    return out

--- a/src/hermes/relation_synonyms.py
+++ b/src/hermes/relation_synonyms.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from dataclasses import dataclass
 
 from hermes.canonical import (
@@ -38,7 +37,7 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class SynonymGroup:
     canonical: str
-    members: list[str]
+    members: tuple[str, ...]
     confidence: float
 
 
@@ -90,10 +89,12 @@ def _coerce_json(content: str) -> dict | None:
         parsed = json.loads(content)
         return parsed if isinstance(parsed, dict) else None
     except json.JSONDecodeError:
-        match = re.search(r"```(?:json)?\s*(.*?)```", content, re.DOTALL)
-        if match:
+        # First-brace / last-brace slice -- robust to conversational wrapping
+        # and avoids a regex on uncontrolled input (CodeQL ReDoS).
+        start, end = content.find("{"), content.rfind("}")
+        if start != -1 and end > start:
             try:
-                parsed = json.loads(match.group(1))
+                parsed = json.loads(content[start : end + 1])
                 return parsed if isinstance(parsed, dict) else None
             except json.JSONDecodeError:
                 return None
@@ -165,5 +166,5 @@ def parse_synonym_response(content: str, candidates: list[str]) -> list[SynonymG
             confidence = 0.7
         confidence = max(0.0, min(1.0, float(confidence)))
 
-        out.append(SynonymGroup(canonical, members_surface, confidence))
+        out.append(SynonymGroup(canonical, tuple(members_surface), confidence))
     return out

--- a/src/hermes/relation_synonyms.py
+++ b/src/hermes/relation_synonyms.py
@@ -27,7 +27,7 @@ import re
 from dataclasses import dataclass
 
 from hermes.canonical import (
-    _RESERVED_PREDICATES,
+    RESERVED_PREDICATES,
     canonicalize_predicate,
     normalize_predicate_surface,
 )
@@ -73,8 +73,8 @@ def build_synonym_messages(
     candidates = [
         p
         for p in predicates
-        if normalize_predicate_surface(p) not in _RESERVED_PREDICATES
-        and normalize_predicate_surface(p)
+        if (surf := normalize_predicate_surface(p))
+        and surf not in RESERVED_PREDICATES
     ]
     ctx = f"Domain context: {context}\n\n" if context else ""
     user = f"{ctx}Candidates: {', '.join(candidates)}\n\nGroup the synonyms."
@@ -85,6 +85,8 @@ def build_synonym_messages(
 
 
 def _coerce_json(content: str) -> dict | None:
+    if not isinstance(content, str):
+        return None
     try:
         return json.loads(content)
     except json.JSONDecodeError:
@@ -111,9 +113,7 @@ def parse_synonym_response(
 
     # candidate surfaces by canonical key (what the members may reference)
     allowed_surface = {
-        normalize_predicate_surface(c)
-        for c in candidates
-        if normalize_predicate_surface(c)
+        surf for c in candidates if (surf := normalize_predicate_surface(c))
     }
 
     out: list[SynonymGroup] = []
@@ -135,7 +135,7 @@ def parse_synonym_response(
             if not surface or surface not in allowed_surface:
                 bad = True  # hallucinated or empty member
                 break
-            if surface in _RESERVED_PREDICATES:
+            if surface in RESERVED_PREDICATES:
                 bad = True  # reserved relation anywhere kills the group
                 break
             canon = canonicalize_predicate(surface)
@@ -149,10 +149,15 @@ def parse_synonym_response(
 
         # canonical label: the LLM's pick if it is a real member, else the
         # first member (deterministic) -- never a hallucinated/reserved name
-        proposed = normalize_predicate_surface(str(grp.get("canonical", "")))
+        raw_canonical = grp.get("canonical")
+        proposed = (
+            normalize_predicate_surface(raw_canonical)
+            if isinstance(raw_canonical, str)
+            else ""
+        )
         canonical = (
             proposed
-            if proposed in members_surface and proposed not in _RESERVED_PREDICATES
+            if proposed in members_surface and proposed not in RESERVED_PREDICATES
             else members_surface[0]
         )
 

--- a/tests/test_relation_synonyms_endpoint.py
+++ b/tests/test_relation_synonyms_endpoint.py
@@ -1,0 +1,91 @@
+"""Tests for the /relation-synonyms endpoint (hermes#133, H3).
+
+The relation-axis naming pass: the LLM proposes descriptive-relation synonym
+groups; the endpoint validates fail-closed (epic #131: no reserved typing
+relation in any group). Every test monkeypatches generate_completion; no
+live LLM calls. Parse/validation rules are covered in
+tests/unit/test_relation_synonyms.py -- here we cover the HTTP contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+import hermes.main as m
+from fastapi.testclient import TestClient
+
+client = TestClient(m.app)
+
+
+def _make_completion(content: str):
+    async def fake_completion(messages, temperature=0.0, max_tokens=1024, **kwargs):
+        assert temperature == 0.0
+        fake_completion.last_messages = messages  # type: ignore[attr-defined]
+        return {"choices": [{"message": {"content": content}}]}
+
+    return fake_completion
+
+
+def _post(predicates, context=None):
+    body = {"predicates": predicates, "request_id": "r::0"}
+    if context is not None:
+        body["context"] = context
+    return client.post("/relation-synonyms", json=body)
+
+
+def test_groups_returned_and_canonicalized(monkeypatch):
+    content = json.dumps(
+        {"groups": [{"canonical": "carries", "members": ["HAULS", "DRAGS", "CARRIES"]}]}
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    resp = _post(["HAULS", "DRAGS", "CARRIES", "PRODUCES"])
+    assert resp.status_code == 200
+    groups = resp.json()["groups"]
+    assert len(groups) == 1
+    assert groups[0]["canonical"] == "CARRIES"
+    assert set(groups[0]["members"]) == {"HAULS", "DRAGS", "CARRIES"}
+
+
+def test_reserved_relation_group_rejected(monkeypatch):
+    content = json.dumps(
+        {"groups": [{"canonical": "IS_A", "members": ["IS_A", "SUBTYPE_OF"]}]}
+    )
+    monkeypatch.setattr(m, "generate_completion", _make_completion(content))
+    resp = _post(["IS_A", "SUBTYPE_OF", "PART_OF", "CARRIES"])
+    assert resp.status_code == 200
+    assert resp.json()["groups"] == []
+
+
+def test_fewer_than_two_predicates_short_circuits(monkeypatch):
+    # must not even call the LLM
+    called = {"n": 0}
+
+    async def boom(*a, **k):
+        called["n"] += 1
+        return {"choices": [{"message": {"content": "{}"}}]}
+
+    monkeypatch.setattr(m, "generate_completion", boom)
+    resp = _post(["CARRIES"])
+    assert resp.status_code == 200
+    assert resp.json()["groups"] == []
+    assert called["n"] == 0
+
+
+def test_reserved_predicates_filtered_from_prompt(monkeypatch):
+    fake = _make_completion(json.dumps({"groups": []}))
+    monkeypatch.setattr(m, "generate_completion", fake)
+    _post(["CARRIES", "HAULS", "IS_A"], context="logistics")
+    user = [msg for msg in fake.last_messages if msg["role"] == "user"][0]["content"]
+    assert "IS_A" not in user.split("Candidates:")[-1]
+    assert "logistics" in user
+
+
+def test_llm_not_configured_returns_503(monkeypatch):
+    from hermes.llm import LLMProviderNotConfiguredError
+
+    async def not_configured(*a, **k):
+        raise LLMProviderNotConfiguredError("no key")
+
+    monkeypatch.setattr(m, "generate_completion", not_configured)
+    resp = _post(["HAULS", "CARRIES"])
+    assert resp.status_code == 503

--- a/tests/unit/test_canonical_predicate.py
+++ b/tests/unit/test_canonical_predicate.py
@@ -56,10 +56,11 @@ GOLDEN: list[tuple[str, str]] = [
     ("ASSESS", "ASSESS"),
     ("FOCUS", "FOCUS"),
     ("BASIS", "BASIS"),
-    # polarity markers: never fold to positive form
-    ("DOES_NOT_REFER_TO", "DOES_NOT_REFER_TO"),
+    # negation folds per-token (the NOT/NEVER token is preserved, so it can
+    # never collide with the positive form) -- review #134
+    ("DOES_NOT_REFER_TO", "DOE_NOT_REFER_TO"),
     ("NOT_PART_OF", "NOT_PART_OF"),
-    ("NEVER_OCCURS_WITH", "NEVER_OCCURS_WITH"),
+    ("NEVER_OCCURS_WITH", "NEVER_OCCUR_WITH"),
     # typing relations are fixed points (out of scope, but must not mangle)
     ("IS_A", "IS_A"),
     ("INSTANCE_OF", "INSTANCE_OF"),
@@ -89,12 +90,18 @@ class TestProperties:
             "PRODUCE"
         )
 
-    def test_polarity_marker_blocks_all_folding(self):
-        # the whole predicate is left in normalized-but-unfolded form so it
-        # can never equal its positive sibling
+    def test_negation_folds_but_never_collides_with_positive(self):
+        # negated predicates fold (so their own inflections converge) but the
+        # preserved polarity token keeps them distinct from the positive form
+        assert canonicalize_predicate("does not produces") == canonicalize_predicate(
+            "does not produced"
+        )
         assert canonicalize_predicate("does not produce") != canonicalize_predicate(
             "produces"
         )
+
+    def test_non_string_input_returns_empty(self):
+        assert canonicalize_predicate(None) == ""  # type: ignore[arg-type]
 
     def test_separators_unified(self):
         forms = ["LOCATED IN", "located-in", "Located_In", "  located   in  "]

--- a/tests/unit/test_canonical_predicate.py
+++ b/tests/unit/test_canonical_predicate.py
@@ -90,15 +90,15 @@ class TestProperties:
     def test_present_forms_converge(self):
         # base and 3sg of a long-enough verb reach the same key
         assert canonicalize_predicate("USES") == canonicalize_predicate("USE")
-        assert canonicalize_predicate("PRODUCES") == canonicalize_predicate(
-            "PRODUCE"
-        )
+        assert canonicalize_predicate("PRODUCES") == canonicalize_predicate("PRODUCE")
 
     def test_y_verb_past_tense_converges(self):
         # review #134: -IED past tense must not strand a bare -I
         key = canonicalize_predicate("CARRY")
-        assert key == canonicalize_predicate("CARRIES") == canonicalize_predicate(
-            "CARRIED"
+        assert (
+            key
+            == canonicalize_predicate("CARRIES")
+            == canonicalize_predicate("CARRIED")
         )
         assert canonicalize_predicate("APPLIED") == canonicalize_predicate("APPLIES")
 

--- a/tests/unit/test_canonical_predicate.py
+++ b/tests/unit/test_canonical_predicate.py
@@ -45,9 +45,13 @@ GOLDEN: list[tuple[str, str]] = [
     ("BINDS_TO", "BIND_TO"),
     ("CATALYZES", "CATALYZ"),
     ("CATALYZE", "CATALYZ"),
-    # -ies -> -y
+    # -ies / -ied / -y all converge (review #134: -ied past tense)
     ("CARRIES", "CARRY"),
     ("CARRY", "CARRY"),
+    ("CARRIED", "CARRY"),
+    ("STUDIES", "STUDY"),
+    ("STUDIED", "STUDY"),
+    ("STUDY", "STUDY"),
     # short-token and consonant-cluster guards: no over-strip
     ("IS", "IS"),
     ("HAS", "HAS"),  # -AS guard
@@ -89,6 +93,14 @@ class TestProperties:
         assert canonicalize_predicate("PRODUCES") == canonicalize_predicate(
             "PRODUCE"
         )
+
+    def test_y_verb_past_tense_converges(self):
+        # review #134: -IED past tense must not strand a bare -I
+        key = canonicalize_predicate("CARRY")
+        assert key == canonicalize_predicate("CARRIES") == canonicalize_predicate(
+            "CARRIED"
+        )
+        assert canonicalize_predicate("APPLIED") == canonicalize_predicate("APPLIES")
 
     def test_negation_folds_but_never_collides_with_positive(self):
         # negated predicates fold (so their own inflections converge) but the

--- a/tests/unit/test_canonical_predicate.py
+++ b/tests/unit/test_canonical_predicate.py
@@ -1,0 +1,102 @@
+"""Frozen golden-table tests for canonicalize_predicate (hermes#130, H1).
+
+The edge-axis analog of test_canonical.py: ONE predicate canonicalizer lives
+in hermes.canonical, the deterministic foundation under match-before-mint
+(#132) and synonym-collapse (#133). It folds morphological variants of the
+same descriptive relation onto one canonical UPPER_SNAKE key so the open
+relation vocabulary (2,244 distinct, 62.6% df=1 on the live graph,
+logos-experiments#25) stops sprawling at the source.
+
+FROZEN table = contract. Convergence is the property under test: every
+inflection of a relation must reach the SAME key, so two surface forms that
+mean the same relation compare equal. The key is a stem (ACQUIR), not
+necessarily pretty English -- consistency, not prose, is the job.
+
+Hard constraints encoded below:
+  * polarity markers (NOT/NO/NEVER/...) are NEVER folded onto the positive
+    form -- DOES_NOT_REFER_TO must not collapse to REFERS_TO;
+  * IS_A / INSTANCE_OF / SUBTYPE_OF are out of scope (callers exclude them),
+    asserted here as fixed points so a regression is visible;
+  * idempotent: canonicalize_predicate(canonicalize_predicate(x)) == itself.
+"""
+
+import pytest
+
+from hermes.canonical import canonicalize_predicate
+
+# FROZEN golden table -- (raw_predicate, canonical_key)
+GOLDEN: list[tuple[str, str]] = [
+    # separator / case normalization
+    ("located in", "LOCAT_IN"),
+    ("Located-In", "LOCAT_IN"),
+    ("LOCATED_IN", "LOCAT_IN"),
+    # present-3sg / base / past / gerund all converge (the core property)
+    ("ACQUIRE", "ACQUIR"),
+    ("ACQUIRES", "ACQUIR"),
+    ("ACQUIRED", "ACQUIR"),
+    ("ACQUIRING", "ACQUIR"),
+    ("PRODUCES", "PRODUC"),
+    ("PRODUCED", "PRODUC"),
+    ("PRODUCING", "PRODUC"),
+    # multi-token: every content token folds, preposition kept
+    ("ACTS_IN", "ACT_IN"),
+    ("ACT_IN", "ACT_IN"),
+    ("LOCATES_IN", "LOCAT_IN"),
+    ("BINDS_TO", "BIND_TO"),
+    ("CATALYZES", "CATALYZ"),
+    ("CATALYZE", "CATALYZ"),
+    # -ies -> -y
+    ("CARRIES", "CARRY"),
+    ("CARRY", "CARRY"),
+    # short-token and consonant-cluster guards: no over-strip
+    ("IS", "IS"),
+    ("HAS", "HAS"),  # -AS guard
+    ("USES", "USE"),  # -S strip; -E guard (len<5) keeps the E
+    # -SS / -US / -IS suffix guard (not plurals)
+    ("ASSESS", "ASSESS"),
+    ("FOCUS", "FOCUS"),
+    ("BASIS", "BASIS"),
+    # polarity markers: never fold to positive form
+    ("DOES_NOT_REFER_TO", "DOES_NOT_REFER_TO"),
+    ("NOT_PART_OF", "NOT_PART_OF"),
+    ("NEVER_OCCURS_WITH", "NEVER_OCCURS_WITH"),
+    # typing relations are fixed points (out of scope, but must not mangle)
+    ("IS_A", "IS_A"),
+    ("INSTANCE_OF", "INSTANCE_OF"),
+    ("SUBTYPE_OF", "SUBTYPE_OF"),
+    # empty / whitespace
+    ("", ""),
+    ("   ", ""),
+]
+
+
+@pytest.mark.parametrize("raw,expected", GOLDEN)
+def test_golden(raw, expected):
+    assert canonicalize_predicate(raw) == expected
+
+
+@pytest.mark.parametrize("raw,_", GOLDEN)
+def test_idempotent(raw, _):
+    once = canonicalize_predicate(raw)
+    assert canonicalize_predicate(once) == once
+
+
+class TestProperties:
+    def test_present_forms_converge(self):
+        # base and 3sg of a long-enough verb reach the same key
+        assert canonicalize_predicate("USES") == canonicalize_predicate("USE")
+        assert canonicalize_predicate("PRODUCES") == canonicalize_predicate(
+            "PRODUCE"
+        )
+
+    def test_polarity_marker_blocks_all_folding(self):
+        # the whole predicate is left in normalized-but-unfolded form so it
+        # can never equal its positive sibling
+        assert canonicalize_predicate("does not produce") != canonicalize_predicate(
+            "produces"
+        )
+
+    def test_separators_unified(self):
+        forms = ["LOCATED IN", "located-in", "Located_In", "  located   in  "]
+        keys = {canonicalize_predicate(f) for f in forms}
+        assert len(keys) == 1

--- a/tests/unit/test_combined_extractor.py
+++ b/tests/unit/test_combined_extractor.py
@@ -485,6 +485,10 @@ class TestClosedVocabPrompt:
         assert "LOCATED_IN" in prompt
         assert "PART_OF" in prompt
         assert "only mint a NEW" in prompt
+        # the clause must sit before the JSON-only sign-off, not after it
+        assert prompt.index("## Known Relations") < prompt.index(
+            "Return ONLY valid JSON"
+        )
 
     def test_clause_omitted_when_vocab_empty(self, monkeypatch):
         from hermes.combined_extractor import OpenAICombinedExtractor
@@ -504,6 +508,17 @@ class TestClosedVocabPrompt:
         # sorted, capped at 150 -> R000..R149 in, R150.. out
         assert "R149" in prompt
         assert "R150" not in prompt
+
+    def test_non_int_cap_falls_back_without_raising(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, {"LOCATED_IN", "PART_OF"})
+        monkeypatch.setenv("RE_VOCAB_CAP", "not-a-number")
+        # must not raise; falls back to the default cap and still injects
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        assert "## Known Relations" in prompt
+        assert "LOCATED_IN" in prompt
 
     def test_fail_soft_when_vocab_raises(self, monkeypatch):
         from hermes.combined_extractor import OpenAICombinedExtractor

--- a/tests/unit/test_combined_extractor.py
+++ b/tests/unit/test_combined_extractor.py
@@ -454,3 +454,69 @@ class TestSingleton:
         inst = get_combined_instance()
         assert isinstance(inst, OpenAICombinedExtractor)
         mod._combined_instance = None
+
+
+class TestClosedVocabPrompt:
+    """H5: closed-vocabulary clause injected into the combined RE prompt.
+
+    The clause reuses the live match-before-mint vocabulary
+    (``get_predicate_vocabulary().known()``) so the model prefers an existing
+    predicate over minting a near-duplicate -- the source-side df=1 lever.
+    """
+
+    @staticmethod
+    def _patch_vocab(monkeypatch, known):
+        class _StubVocab:
+            def known(self):
+                return set(known)
+
+        monkeypatch.setattr(
+            "hermes.predicate_resolver.get_predicate_vocabulary",
+            lambda: _StubVocab(),
+        )
+
+    def test_clause_injected_when_vocab_present(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, {"LOCATED_IN", "PART_OF"})
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        assert "## Known Relations" in prompt
+        assert "LOCATED_IN" in prompt
+        assert "PART_OF" in prompt
+        assert "only mint a NEW" in prompt
+
+    def test_clause_omitted_when_vocab_empty(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, set())
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        assert "## Known Relations" not in prompt
+
+    def test_cap_respected(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, {f"R{i:03d}" for i in range(200)})
+        monkeypatch.setenv("RE_VOCAB_CAP", "150")
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        # sorted, capped at 150 -> R000..R149 in, R150.. out
+        assert "R149" in prompt
+        assert "R150" not in prompt
+
+    def test_fail_soft_when_vocab_raises(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        class _Boom:
+            def known(self):
+                raise RuntimeError("redis down")
+
+        monkeypatch.setattr(
+            "hermes.predicate_resolver.get_predicate_vocabulary",
+            lambda: _Boom(),
+        )
+        # must not raise; falls back to the open prompt
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        assert "## Known Relations" not in prompt

--- a/tests/unit/test_milvus_ensure_collection.py
+++ b/tests/unit/test_milvus_ensure_collection.py
@@ -41,7 +41,7 @@ def _reset_milvus_globals() -> Any:
     mc._milvus_collection = None
     mc._collection_name = "unit_embeddings"
     yield
-    (mc._milvus_connected, mc._milvus_collection, mc._collection_name) = saved
+    mc._milvus_connected, mc._milvus_collection, mc._collection_name = saved
 
 
 def test_fast_path_returns_fresh_server_reference(

--- a/tests/unit/test_predicate_resolver.py
+++ b/tests/unit/test_predicate_resolver.py
@@ -1,0 +1,107 @@
+"""Tests for catalog-aware prefer-existing predicate resolution (hermes#132, H2).
+
+Match-before-mint for descriptive relations: a candidate predicate is
+checked against the known vocabulary by its H1 canonical key before a new
+one is minted. The STORED relation is a readable surface form (first-seen
+per canonical class); minting is the exception. IS_A / INSTANCE_OF /
+SUBTYPE_OF bypass the path untouched. Every resolution carries provenance.
+"""
+
+import pytest
+
+from hermes.predicate_resolver import (
+    PredicateVocabulary,
+    index_vocabulary,
+    resolve_predicate,
+)
+
+
+class TestIndexVocabulary:
+    def test_groups_by_canonical_keeping_min_surface(self):
+        idx = index_vocabulary(["LOCATED_IN", "LOCATES_IN", "PRODUCES"])
+        # LOCATED_IN / LOCATES_IN share canonical LOCAT_IN -> one entry, the
+        # lexicographically-min surface is the representative (deterministic)
+        assert idx["LOCAT_IN"] == "LOCATED_IN"
+        assert idx["PRODUC"] == "PRODUCES"
+
+    def test_reserved_predicates_excluded_from_index(self):
+        idx = index_vocabulary(["IS_A", "INSTANCE_OF", "PART_OF"])
+        assert "IS_A" not in idx and "INSTANCE_OF" not in idx
+        assert idx  # PART_OF survives
+
+
+class TestResolveAgainstFixedIndex:
+    def _idx(self):
+        return index_vocabulary(["LOCATED_IN", "PRODUCES", "PART_OF"])
+
+    def test_exact_canonical_match_reuses_existing_surface(self):
+        r = resolve_predicate("locates in", self._idx())
+        assert r.relation == "LOCATED_IN"
+        assert r.status == "matched"
+        assert r.canonical == "LOCAT_IN"
+        assert r.raw == "locates in"
+
+    def test_inflected_variant_matches(self):
+        assert resolve_predicate("PRODUCED", self._idx()).relation == "PRODUCES"
+        assert resolve_predicate("PRODUCING", self._idx()).status == "matched"
+
+    def test_unknown_predicate_mints_readable_surface(self):
+        r = resolve_predicate("ORBITS_AROUND", self._idx())
+        assert r.relation == "ORBITS_AROUND"  # surface, not the ORBIT_AROUND stem
+        assert r.status == "minted"
+        assert r.canonical == "ORBIT_AROUND"
+
+    def test_reserved_relation_passes_through(self):
+        r = resolve_predicate("IS_A", self._idx())
+        assert r.relation == "IS_A" and r.status == "reserved"
+
+    def test_typing_relations_never_match_descriptive_vocab(self):
+        # SUBTYPE_OF must not be folded into PART_OF or anything else
+        r = resolve_predicate("SUBTYPE_OF", self._idx())
+        assert r.status == "reserved" and r.relation == "SUBTYPE_OF"
+
+    def test_polarity_predicate_mints_separately(self):
+        idx = index_vocabulary(["REFERS_TO"])
+        r = resolve_predicate("DOES_NOT_REFER_TO", idx)
+        assert r.status == "minted"
+        assert r.relation == "DOES_NOT_REFER_TO"
+
+    def test_empty_predicate_is_dropped(self):
+        r = resolve_predicate("   ", self._idx())
+        assert r.relation == "" and r.status == "empty"
+
+
+class TestPredicateVocabularyAccumulation:
+    def test_first_occurrence_mints_then_variants_match(self):
+        vocab = PredicateVocabulary()
+        first = vocab.resolve("LOCATED_IN")
+        assert first.status == "minted"
+        # a later inflected variant in the same process matches the mint
+        second = vocab.resolve("locates in")
+        assert second.status == "matched"
+        assert second.relation == "LOCATED_IN"
+
+    def test_seed_injects_known_vocabulary(self):
+        vocab = PredicateVocabulary()
+        vocab.seed(["PART_OF", "PRODUCES"])
+        r = vocab.resolve("PRODUCED")
+        assert r.status == "matched" and r.relation == "PRODUCES"
+
+    def test_reserved_never_added_to_vocabulary(self):
+        vocab = PredicateVocabulary()
+        vocab.resolve("IS_A")
+        assert "IS_A" not in vocab.known()
+        assert vocab.resolve("INSTANCE_OF").status == "reserved"
+
+    def test_known_returns_current_surfaces(self):
+        vocab = PredicateVocabulary()
+        vocab.resolve("ORBITS")
+        vocab.resolve("PART_OF")
+        assert vocab.known() == {"ORBITS", "PART_OF"}
+
+    def test_accumulation_is_order_stable_on_surface_choice(self):
+        # whichever surface is seen FIRST for a canonical class wins and sticks
+        vocab = PredicateVocabulary()
+        vocab.resolve("LOCATES_IN")  # mints this surface
+        r = vocab.resolve("LOCATED_IN")  # same canonical -> matches the mint
+        assert r.relation == "LOCATES_IN" and r.status == "matched"

--- a/tests/unit/test_predicate_resolver.py
+++ b/tests/unit/test_predicate_resolver.py
@@ -7,8 +7,6 @@ per canonical class); minting is the exception. IS_A / INSTANCE_OF /
 SUBTYPE_OF bypass the path untouched. Every resolution carries provenance.
 """
 
-import pytest
-
 from hermes.predicate_resolver import (
     PredicateVocabulary,
     index_vocabulary,

--- a/tests/unit/test_predicate_resolver_wiring.py
+++ b/tests/unit/test_predicate_resolver_wiring.py
@@ -1,0 +1,64 @@
+"""H2 wiring: the OpenAI/combined relation parse path resolves predicates
+and attaches provenance (hermes#132).
+
+Exercises OpenAIRelationExtractor._parse_response (the shared choke point
+for the openai AND combined backends) against a fresh, isolated
+vocabulary so match-before-mint is observable end to end.
+"""
+
+import json
+
+import pytest
+
+import hermes.predicate_resolver as pr
+from hermes.relation_extractor import OpenAIRelationExtractor
+
+
+@pytest.fixture
+def fresh_vocab(monkeypatch):
+    """Swap the process singleton for an isolated, empty vocabulary."""
+    vocab = pr.PredicateVocabulary()
+    monkeypatch.setattr(pr, "_VOCABULARY", vocab)
+    monkeypatch.setattr(
+        "hermes.relation_extractor.get_predicate_vocabulary", lambda: vocab
+    )
+    return vocab
+
+
+def _payload(*relations):
+    return json.dumps({"relations": list(relations)})
+
+
+def test_provenance_attached_on_mint(fresh_vocab):
+    content = _payload(
+        {"source_name": "A", "target_name": "B", "relation": "orbits around"}
+    )
+    out = OpenAIRelationExtractor._parse_response(content, {"A", "B"})
+    assert len(out) == 1
+    prov = out[0]["properties"]["predicate"]
+    assert prov["status"] == "minted"
+    assert prov["raw"] == "orbits around"
+    assert prov["canonical"] == "ORBIT_AROUND"
+    assert out[0]["relation"] == "ORBITS_AROUND"  # readable surface, not stem
+
+
+def test_inflected_variant_matches_earlier_mint(fresh_vocab):
+    fresh_vocab.seed(["LOCATED_IN"])
+    content = _payload(
+        {"source_name": "A", "target_name": "B", "relation": "locates in"}
+    )
+    out = OpenAIRelationExtractor._parse_response(content, {"A", "B"})
+    assert out[0]["relation"] == "LOCATED_IN"
+    assert out[0]["properties"]["predicate"]["status"] == "matched"
+
+
+def test_two_variants_in_one_batch_collapse_to_one_edge(fresh_vocab):
+    # PRODUCES and PRODUCED between the same pair -> same canonical -> the
+    # (src,tgt,relation) dedup now collapses them into a single edge
+    content = _payload(
+        {"source_name": "A", "target_name": "B", "relation": "PRODUCES"},
+        {"source_name": "A", "target_name": "B", "relation": "PRODUced"},
+    )
+    out = OpenAIRelationExtractor._parse_response(content, {"A", "B"})
+    assert len(out) == 1
+    assert out[0]["relation"] == "PRODUCES"

--- a/tests/unit/test_relation_registry.py
+++ b/tests/unit/test_relation_registry.py
@@ -21,7 +21,9 @@ def _redis_with(snapshot):
 
 def test_seeds_vocabulary_from_snapshot_on_boot():
     vocab = PredicateVocabulary()
-    redis = _redis_with({"LOCATED_IN": {"edge_count": 12}, "PRODUCES": {"edge_count": 5}})
+    redis = _redis_with(
+        {"LOCATED_IN": {"edge_count": 12}, "PRODUCES": {"edge_count": 5}}
+    )
     RelationRegistry(redis, vocab)
     assert vocab.known() == {"LOCATED_IN", "PRODUCES"}
     # reads the relation key, not the type key

--- a/tests/unit/test_relation_registry.py
+++ b/tests/unit/test_relation_registry.py
@@ -1,0 +1,87 @@
+"""Tests for RelationRegistry (hermes#137, H4).
+
+Mirrors TypeRegistry: reads the descriptive-relation snapshot Sophia
+publishes to logos:ontology:relations (sophia#190) and seeds the
+match-before-mint PredicateVocabulary, on boot and on each
+proposal_processed event. Fail-soft.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from hermes.predicate_resolver import PredicateVocabulary
+from hermes.relation_registry import RelationRegistry
+
+
+def _redis_with(snapshot):
+    r = MagicMock()
+    r.get.return_value = json.dumps(snapshot) if snapshot is not None else None
+    return r
+
+
+def test_seeds_vocabulary_from_snapshot_on_boot():
+    vocab = PredicateVocabulary()
+    redis = _redis_with({"LOCATED_IN": {"edge_count": 12}, "PRODUCES": {"edge_count": 5}})
+    RelationRegistry(redis, vocab)
+    assert vocab.known() == {"LOCATED_IN", "PRODUCES"}
+    # reads the relation key, not the type key
+    assert redis.get.call_args[0][0] == "logos:ontology:relations"
+
+
+def test_seeded_vocabulary_matches_inflected_variant():
+    vocab = PredicateVocabulary()
+    RelationRegistry(_redis_with({"LOCATED_IN": {"edge_count": 3}}), vocab)
+    r = vocab.resolve("locates in")
+    assert r.status == "matched" and r.relation == "LOCATED_IN"
+
+
+def test_missing_snapshot_leaves_vocabulary_empty_no_error():
+    vocab = PredicateVocabulary()
+    RelationRegistry(_redis_with(None), vocab)
+    assert vocab.known() == set()
+
+
+def test_redis_failure_is_swallowed():
+    vocab = PredicateVocabulary()
+    redis = MagicMock()
+    redis.get.side_effect = RuntimeError("redis down")
+    RelationRegistry(redis, vocab)  # must not raise
+    assert vocab.known() == set()
+
+
+def test_non_dict_snapshot_is_ignored():
+    vocab = PredicateVocabulary()
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(["LOCATED_IN"])  # wrong shape
+    RelationRegistry(redis, vocab)
+    assert vocab.known() == set()
+
+
+def test_reload_on_event_seeds_new_relations():
+    vocab = PredicateVocabulary()
+    redis = _redis_with({"LOCATED_IN": {"edge_count": 1}})
+    reg = RelationRegistry(redis, vocab)
+    # Sophia publishes a new relation; next snapshot includes it
+    redis.get.return_value = json.dumps(
+        {"LOCATED_IN": {"edge_count": 1}, "ORBITS_AROUND": {"edge_count": 2}}
+    )
+    reg.on_proposal_processed({"event_type": "proposal_processed"})
+    assert "ORBITS_AROUND" in vocab.known()
+
+
+def test_reload_preserves_in_process_mints():
+    # a predicate minted in-process (not yet in any snapshot) must survive a
+    # reload -- seed() is additive (the mint round-trips via Sophia later)
+    vocab = PredicateVocabulary()
+    reg = RelationRegistry(_redis_with({"LOCATED_IN": {"edge_count": 1}}), vocab)
+    vocab.resolve("TELEPORTS")  # in-process mint
+    reg.on_proposal_processed({})
+    assert "TELEPORTS" in vocab.known()
+
+
+def test_reserved_relation_in_snapshot_never_seeded():
+    # defense in depth: even if a reserved relation leaks into the snapshot,
+    # the vocabulary never accepts it
+    vocab = PredicateVocabulary()
+    RelationRegistry(_redis_with({"IS_A": {"edge_count": 9}}), vocab)
+    assert "IS_A" not in vocab.known()

--- a/tests/unit/test_relation_synonyms.py
+++ b/tests/unit/test_relation_synonyms.py
@@ -9,7 +9,6 @@ collapse; the canonical label is H1-normalized. Output is a PROPOSAL.
 
 import json
 
-import pytest
 
 from hermes.relation_synonyms import (
     build_synonym_messages,
@@ -27,7 +26,9 @@ CANDIDATES = ["HAULS", "DRAGS", "CARRIES", "PRODUCES", "MAKES", "IS_A", "PART_OF
 class TestParseHappyPath:
     def test_valid_group_kept_and_canonicalized(self):
         out = parse_synonym_response(
-            _content({"canonical": "carries", "members": ["HAULS", "DRAGS", "CARRIES"]}),
+            _content(
+                {"canonical": "carries", "members": ["HAULS", "DRAGS", "CARRIES"]}
+            ),
             CANDIDATES,
         )
         assert len(out) == 1
@@ -39,7 +40,11 @@ class TestParseHappyPath:
     def test_confidence_passed_through_and_clamped(self):
         out = parse_synonym_response(
             _content(
-                {"canonical": "MAKES", "members": ["PRODUCES", "MAKES"], "confidence": 2.0}
+                {
+                    "canonical": "MAKES",
+                    "members": ["PRODUCES", "MAKES"],
+                    "confidence": 2.0,
+                }
             ),
             CANDIDATES,
         )

--- a/tests/unit/test_relation_synonyms.py
+++ b/tests/unit/test_relation_synonyms.py
@@ -1,0 +1,115 @@
+"""Fail-closed contract tests for the relation synonym-collapse pass (#133, H3).
+
+The LLM proposes descriptive-relation synonym groups (HAULS/DRAGS/CARRIES ->
+CARRIES); this module validates server-side. The hard rules (epic #131):
+no group may contain a reserved typing relation; members must come from the
+submitted candidates (no hallucinated predicates); a "group" of one is not a
+collapse; the canonical label is H1-normalized. Output is a PROPOSAL.
+"""
+
+import json
+
+import pytest
+
+from hermes.relation_synonyms import (
+    build_synonym_messages,
+    parse_synonym_response,
+)
+
+
+def _content(*groups):
+    return json.dumps({"groups": list(groups)})
+
+
+CANDIDATES = ["HAULS", "DRAGS", "CARRIES", "PRODUCES", "MAKES", "IS_A", "PART_OF"]
+
+
+class TestParseHappyPath:
+    def test_valid_group_kept_and_canonicalized(self):
+        out = parse_synonym_response(
+            _content({"canonical": "carries", "members": ["HAULS", "DRAGS", "CARRIES"]}),
+            CANDIDATES,
+        )
+        assert len(out) == 1
+        g = out[0]
+        assert g.canonical == "CARRIES"  # normalized surface
+        assert set(g.members) == {"HAULS", "DRAGS", "CARRIES"}
+        assert 0.0 <= g.confidence <= 1.0
+
+    def test_confidence_passed_through_and_clamped(self):
+        out = parse_synonym_response(
+            _content(
+                {"canonical": "MAKES", "members": ["PRODUCES", "MAKES"], "confidence": 2.0}
+            ),
+            CANDIDATES,
+        )
+        assert out[0].confidence == 1.0
+
+
+class TestFailClosed:
+    def test_group_with_reserved_relation_is_dropped(self):
+        out = parse_synonym_response(
+            _content({"canonical": "IS_A", "members": ["IS_A", "PART_OF"]}),
+            CANDIDATES,
+        )
+        assert out == []
+
+    def test_reserved_member_anywhere_drops_the_group(self):
+        out = parse_synonym_response(
+            _content({"canonical": "CARRIES", "members": ["CARRIES", "INSTANCE_OF"]}),
+            CANDIDATES + ["INSTANCE_OF"],
+        )
+        assert out == []
+
+    def test_hallucinated_member_drops_the_group(self):
+        out = parse_synonym_response(
+            _content({"canonical": "CARRIES", "members": ["CARRIES", "TELEPORTS"]}),
+            CANDIDATES,
+        )
+        assert out == []
+
+    def test_singleton_group_is_not_a_collapse(self):
+        out = parse_synonym_response(
+            _content({"canonical": "CARRIES", "members": ["CARRIES"]}),
+            CANDIDATES,
+        )
+        assert out == []
+
+    def test_members_dedup_by_canonical_then_singleton_dropped(self):
+        # CARRIES + CARRY are the same canonical -> effectively one member
+        out = parse_synonym_response(
+            _content({"canonical": "CARRIES", "members": ["CARRIES", "CARRY"]}),
+            CANDIDATES + ["CARRY"],
+        )
+        assert out == []
+
+    def test_malformed_json_returns_empty(self):
+        assert parse_synonym_response("not json", CANDIDATES) == []
+
+    def test_missing_groups_key_returns_empty(self):
+        assert parse_synonym_response(json.dumps({"x": 1}), CANDIDATES) == []
+
+    def test_canonical_not_among_members_is_repaired_to_a_member(self):
+        # if the LLM names a canonical that isn't one of the members, keep the
+        # group but the canonical must be a real member's surface
+        out = parse_synonym_response(
+            _content({"canonical": "TRANSPORTS", "members": ["HAULS", "CARRIES"]}),
+            CANDIDATES,
+        )
+        assert len(out) == 1
+        assert out[0].canonical in {"HAULS", "CARRIES"}
+
+
+class TestPromptConstruction:
+    def test_messages_list_the_candidates_and_forbid_is_a(self):
+        msgs = build_synonym_messages(["HAULS", "CARRIES"], context="cargo domain")
+        blob = " ".join(m["content"] for m in msgs)
+        assert "HAULS" in blob and "CARRIES" in blob
+        assert "IS_A" in blob  # the prompt must state the exclusion
+        assert "cargo domain" in blob
+
+    def test_reserved_candidates_filtered_from_the_prompt(self):
+        msgs = build_synonym_messages(["CARRIES", "IS_A", "SUBTYPE_OF"])
+        user = [m for m in msgs if m["role"] == "user"][0]["content"]
+        # IS_A/SUBTYPE_OF must not be offered as groupable candidates
+        assert "SUBTYPE_OF" not in user.split("Candidates:")[-1]


### PR DESCRIPTION
**Opened for review + tracking, not for immediate merge.** This is the source-fix substrate; landing it on `main` changes live ingestion behaviour, which is a deploy decision being deferred (validate-on-branch). It just never had a PR — fixing that so it's reviewable and tracked.

## What

The complete **relation-vocabulary naming-driven-typing** substrate — the extraction-time *source fix* for relation over-generation (the df=1 problem). Gives the edge axis the NDT treatment the node axis already has. Epic: #131. `main` currently has none of this (12 commits ahead).

- **H1 — `canonicalize_predicate`** (#130, `canonical.py`): morphological folding for descriptive relations; per-token stemming, negated/reserved predicates kept distinct.
- **H2 — match-before-mint** (#132, `predicate_resolver.py` / `relation_extractor.py`): catalog-aware prefer-existing predicate selection at extraction — resolve an inflected variant to an existing predicate instead of minting a near-duplicate.
- **H3 — synonym-collapse endpoint** (#133, `relation_synonyms.py`): the descriptive-relation naming pass.
- **H4 — `RelationRegistry`** (#137, `relation_registry.py` / `main.py`): seeds the match-before-mint vocabulary from the Redis `logos:ontology:relations` snapshot on boot and on `proposal_processed`, making it cross-process.
- **H5 — closed-vocabulary prompting** (#140/#141, `combined_extractor.py`): injects the known vocabulary into the combined NER+RE prompt with reuse-don't-mint pressure. Fail-soft, `RE_VOCAB_CAP`-bounded.

Flow: H1 normalizes → H2 matches before minting → H4 keeps the vocab fresh + shared → H3 collapses synonyms → H5 stops new sprawl at the prompt.

## Why it matters

This is the **load-bearing half of the df=1 < 0.25 gate**. The W0.3b consolidation already cleaned the *existing* tail (df=1 0.626 → 0.424 on the live graph), but that **erodes without this live** — new ingestion re-mints one-offs. Per the NER/RE bake-off (logos-experiments#38), closed-vocab prompting on the current cheap model was the single biggest source lever (relation label-F1 0.171 → 0.439).

## Validation status

- Offline / per-component: each H reviewed on its own sub-PR (H1 #134, H3 #136, H4 #138, H5 #141); H5 also re-run against the bake-off harness.
- **Remaining:** end-to-end — does H5 actually reduce one-off minting on a real ingestion run? (the minting-rate A/B). Doesn't need a merge to run.

Per-component tickets under epic #131. Companion cleanup: logos-experiments#34 (consolidation, applied).
