### PR TITLE
fix(h5): rank the known-relations window by usage, not alphabetically

### DIFF
--- a/src/hermes/combined_extractor.py
+++ b/src/hermes/combined_extractor.py
@@ -124,12 +124,19 @@ class OpenAICombinedExtractor:
         ``RE_VOCAB_CAP`` (default 150) because the live vocabulary can hold
         thousands of surfaces; the cap keeps prompt tokens in check and, as
         consolidation shrinks the vocabulary below it, the full clean set is
-        injected automatically.
+        injected automatically. The window is ranked by graph usage
+        (``edge_count`` from Sophia's relation snapshot, via
+        ``get_relation_counts``) so the capped slice shows the model the
+        reusable core rather than an alphabetical prefix.
         """
         try:
-            from hermes.predicate_resolver import get_predicate_vocabulary
+            from hermes.predicate_resolver import (
+                get_predicate_vocabulary,
+                get_relation_counts,
+            )
 
             known = get_predicate_vocabulary().known()
+            counts = get_relation_counts()
         except Exception:
             logger.warning("H5: predicate vocabulary unavailable; using open RE prompt")
             return ""
@@ -145,7 +152,11 @@ class OpenAICombinedExtractor:
                 os.getenv("RE_VOCAB_CAP"),
             )
             cap = 150
-        vocab = sorted(known)[:cap]
+        # Rank by graph usage (Sophia's snapshot edge_count) so the capped
+        # window advertises the reusable core, not an alphabetical slice;
+        # surfaces without a count (e.g. just minted in-process) rank last.
+        # Alphabetical tiebreak keeps the clause deterministic.
+        vocab = sorted(known, key=lambda s: (-counts.get(s, 0), s))[:cap]
         if not vocab:  # cap sliced everything away -> open prompt, not an empty clause
             return ""
         return (

--- a/src/hermes/predicate_resolver.py
+++ b/src/hermes/predicate_resolver.py
@@ -128,3 +128,22 @@ _VOCABULARY = PredicateVocabulary()
 
 def get_predicate_vocabulary() -> PredicateVocabulary:
     return _VOCABULARY
+
+
+# Graph usage counts (surface -> edge_count) published by RelationRegistry
+# from Sophia's relation snapshot. Consumed by the H5 known-relations clause
+# to rank the advertised vocabulary window by usage instead of slicing it
+# alphabetically. Replaced wholesale on every snapshot load (atomic rebind;
+# readers only .get on the current dict); {} until the first snapshot lands.
+_RELATION_COUNTS: dict[str, int] = {}
+
+
+def set_relation_counts(counts: dict[str, int]) -> None:
+    """Replace the published usage-count map (surface -> edge_count)."""
+    global _RELATION_COUNTS
+    _RELATION_COUNTS = dict(counts)
+
+
+def get_relation_counts() -> dict[str, int]:
+    """Usage counts for known relations; {} before the first snapshot."""
+    return _RELATION_COUNTS

--- a/src/hermes/predicate_resolver.py
+++ b/src/hermes/predicate_resolver.py
@@ -133,17 +133,23 @@ def get_predicate_vocabulary() -> PredicateVocabulary:
 # Graph usage counts (surface -> edge_count) published by RelationRegistry
 # from Sophia's relation snapshot. Consumed by the H5 known-relations clause
 # to rank the advertised vocabulary window by usage instead of slicing it
-# alphabetically. Replaced wholesale on every snapshot load (atomic rebind;
-# readers only .get on the current dict); {} until the first snapshot lands.
+# alphabetically. Replaced wholesale on every snapshot load; {} until the
+# first snapshot lands. Guarded by the same lock pattern as _VOCABULARY so
+# the module's two singletons share one threading model (and stay correct
+# on free-threaded builds, where a bare global rebind is no longer atomic).
 _RELATION_COUNTS: dict[str, int] = {}
+_RELATION_COUNTS_LOCK = threading.Lock()
 
 
 def set_relation_counts(counts: dict[str, int]) -> None:
     """Replace the published usage-count map (surface -> edge_count)."""
     global _RELATION_COUNTS
-    _RELATION_COUNTS = dict(counts)
+    snapshot = dict(counts)
+    with _RELATION_COUNTS_LOCK:
+        _RELATION_COUNTS = snapshot
 
 
 def get_relation_counts() -> dict[str, int]:
     """Usage counts for known relations; {} before the first snapshot."""
-    return _RELATION_COUNTS
+    with _RELATION_COUNTS_LOCK:
+        return _RELATION_COUNTS

--- a/src/hermes/relation_registry.py
+++ b/src/hermes/relation_registry.py
@@ -20,7 +20,8 @@ import json
 import logging
 from typing import Any
 
-from hermes.predicate_resolver import PredicateVocabulary
+from hermes.canonical import normalize_predicate_surface
+from hermes.predicate_resolver import PredicateVocabulary, set_relation_counts
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,21 @@ class RelationRegistry:
             added,
             len(data),
         )
+        # Retain the snapshot's usage counts for the H5 prompt window: the
+        # known-relations clause ranks the advertised vocabulary by
+        # edge_count so the model is shown the reusable core rather than an
+        # alphabetical slice. Surfaces minted in-process have no count yet
+        # and simply rank last; a wholesale replace tracks Sophia's view.
+        counts: dict[str, int] = {}
+        for raw_surface, props in data.items():
+            surface = normalize_predicate_surface(raw_surface)
+            if not surface or not isinstance(props, dict):
+                continue
+            try:
+                counts[surface] = int(props.get("edge_count", 0))
+            except (TypeError, ValueError):
+                counts[surface] = 0
+        set_relation_counts(counts)
 
     def on_proposal_processed(self, event: dict) -> None:
         """EventBus callback — re-read the snapshot and re-seed (additive)."""

--- a/tests/unit/test_combined_extractor.py
+++ b/tests/unit/test_combined_extractor.py
@@ -498,6 +498,40 @@ class TestClosedVocabPrompt:
 
         assert "## Known Relations" not in prompt
 
+    @staticmethod
+    def _patch_counts(monkeypatch, counts):
+        monkeypatch.setattr(
+            "hermes.predicate_resolver.get_relation_counts",
+            lambda: dict(counts),
+        )
+
+    def test_window_ranked_by_usage_not_alphabetical(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, {"AAA_OF", "PART_OF", "LOCATED_IN"})
+        self._patch_counts(monkeypatch, {"PART_OF": 100, "LOCATED_IN": 40})
+        monkeypatch.setenv("RE_VOCAB_CAP", "2")
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        # usage-ranked window: the frequent core makes the cap; the
+        # alphabetically-first zero-count surface is squeezed out
+        assert "PART_OF" in prompt
+        assert "LOCATED_IN" in prompt
+        assert "AAA_OF" not in prompt
+
+    def test_window_alphabetical_when_counts_absent(self, monkeypatch):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        self._patch_vocab(monkeypatch, {"B_OF", "A_OF", "C_OF"})
+        self._patch_counts(monkeypatch, {})
+        monkeypatch.setenv("RE_VOCAB_CAP", "2")
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+
+        # no counts yet (pre-snapshot) -> deterministic alphabetical fallback
+        assert "A_OF" in prompt
+        assert "B_OF" in prompt
+        assert "C_OF" not in prompt
+
     def test_cap_respected(self, monkeypatch):
         from hermes.combined_extractor import OpenAICombinedExtractor
 

--- a/tests/unit/test_relation_registry.py
+++ b/tests/unit/test_relation_registry.py
@@ -30,6 +30,28 @@ def test_seeds_vocabulary_from_snapshot_on_boot():
     assert redis.get.call_args[0][0] == "logos:ontology:relations"
 
 
+def test_boot_publishes_usage_counts_for_prompt_ranking(monkeypatch):
+    import hermes.predicate_resolver as pr
+
+    monkeypatch.setattr(pr, "_RELATION_COUNTS", {})
+    vocab = PredicateVocabulary()
+    RelationRegistry(
+        _redis_with({"PART_OF": {"edge_count": 100}, "LOCATED_IN": {"edge_count": 7}}),
+        vocab,
+    )
+    # the snapshot's edge_counts are retained for the H5 window ranking
+    assert pr.get_relation_counts() == {"PART_OF": 100, "LOCATED_IN": 7}
+
+
+def test_malformed_edge_count_publishes_zero(monkeypatch):
+    import hermes.predicate_resolver as pr
+
+    monkeypatch.setattr(pr, "_RELATION_COUNTS", {})
+    vocab = PredicateVocabulary()
+    RelationRegistry(_redis_with({"PART_OF": {"edge_count": "many"}}), vocab)
+    assert pr.get_relation_counts() == {"PART_OF": 0}
+
+
 def test_seeded_vocabulary_matches_inflected_variant():
     vocab = PredicateVocabulary()
     RelationRegistry(_redis_with({"LOCATED_IN": {"edge_count": 3}}), vocab)


### PR DESCRIPTION
H5 follow-on for epic #131 — the known-relations window shown to the extractor was assembled alphabetically; ranking by usage keeps high-traffic predicates in-window.

Cherry-picked from local branch `feat/hermes-h5-ranked-vocab-window` (`297391a`), deliberately excluding the #139 embed-batch commits already staged on `epic/nl-extraction`.

Validation (2026-06-11 fresh-corpus probe, logos-experiments structural-health): distinct predicates −42%, df=1 singletons −44%, EV@128 = 0.497 vs the 0.171 bar (graph-vs-graph caveat).
