### PR TITLE
fix(hermes#144): strip determiners, reject pronoun/preposition junk in entity names

### DIFF
--- a/src/hermes/name_normalizer.py
+++ b/src/hermes/name_normalizer.py
@@ -1,9 +1,10 @@
 """Post-extraction entity name normalization.
 
-Cleans entity names via lowercasing, singularization, and deduplication
-before they leave Hermes.  Word-level singularization is delegated to the
-shared inflect-based core in ``hermes.canonical`` -- one engine for entity,
-edge, and type names.
+Cleans entity names via lowercasing, singularization, leading-determiner
+stripping, junk rejection (bare pronouns, preposition-led phrases), and
+deduplication before they leave Hermes.  Word-level singularization is
+delegated to the shared inflect-based core in ``hermes.canonical`` -- one
+engine for entity, edge, and type names.
 """
 
 from __future__ import annotations
@@ -13,6 +14,145 @@ import logging
 from hermes.canonical import singularize_word
 
 logger = logging.getLogger(__name__)
+
+# Leading tokens stripped from names: determiners and possessive pronouns
+# carry no referent of their own ("the morning light" -> "morning light").
+# A name that strips to nothing is dropped.
+_DETERMINERS = {
+    "a",
+    "an",
+    "the",
+    "this",
+    "that",
+    "these",
+    "those",
+    "my",
+    "your",
+    "his",
+    "her",
+    "its",
+    "our",
+    "their",
+    "some",
+    "any",
+    "each",
+    "every",
+    "no",
+}
+
+# A name that is nothing but a pronoun has no cross-document referent.
+_PRONOUNS = {
+    "i",
+    "me",
+    "my",
+    "mine",
+    "myself",
+    "we",
+    "us",
+    "our",
+    "ours",
+    "ourselves",
+    "you",
+    "your",
+    "yours",
+    "yourself",
+    "yourselves",
+    "he",
+    "him",
+    "his",
+    "himself",
+    "she",
+    "her",
+    "hers",
+    "herself",
+    "it",
+    "its",
+    "itself",
+    "they",
+    "them",
+    "their",
+    "theirs",
+    "themselves",
+    "this",
+    "that",
+    "these",
+    "those",
+    "who",
+    "whom",
+    "whose",
+    "which",
+    "what",
+    "something",
+    "anything",
+    "nothing",
+    "everything",
+    "someone",
+    "anyone",
+    "everyone",
+    "somebody",
+    "anybody",
+    "nobody",
+    "everybody",
+    "one",
+    "none",
+}
+
+# A multi-word name led by a preposition is an adverbial or measure phrase,
+# not an entity ("over two hundred miles per hour"). "up"/"down"/"out"/"off"
+# are deliberately absent: they lead legitimate compounds ("down payment").
+_PREPOSITIONS = {
+    "about",
+    "above",
+    "across",
+    "after",
+    "against",
+    "along",
+    "amid",
+    "among",
+    "around",
+    "at",
+    "before",
+    "behind",
+    "below",
+    "beneath",
+    "beside",
+    "besides",
+    "between",
+    "beyond",
+    "by",
+    "despite",
+    "during",
+    "except",
+    "for",
+    "from",
+    "in",
+    "inside",
+    "into",
+    "near",
+    "of",
+    "on",
+    "onto",
+    "outside",
+    "over",
+    "past",
+    "per",
+    "since",
+    "through",
+    "throughout",
+    "till",
+    "to",
+    "toward",
+    "towards",
+    "under",
+    "underneath",
+    "until",
+    "unto",
+    "upon",
+    "via",
+    "with",
+    "within",
+    "without",
+}
 
 
 def _lemmatize_word(word: str) -> str:
@@ -59,8 +199,43 @@ def _lemmatize_name(name: str, original_name: str | None = None) -> str:
     return " ".join(result)
 
 
+def clean_entity_name(name: str, original_name: str | None = None) -> str:
+    """Full name-cleaning pipeline: strip leading determiners, then lemmatize.
+
+    Expects ``name`` already lowercased (``original_name`` carries the raw
+    casing for the proper-noun heuristic in ``_lemmatize_name``). Returns ""
+    when nothing survives the strip (caller drops the entity).
+    """
+    words = name.split()
+    orig_words = original_name.split() if original_name else []
+    while words and words[0] in _DETERMINERS:
+        words.pop(0)
+        if orig_words:
+            orig_words.pop(0)
+    if not words:
+        return ""
+    stripped_orig = " ".join(orig_words) if orig_words else None
+    return _lemmatize_name(" ".join(words), original_name=stripped_orig)
+
+
+def is_junk_entity_name(name: str) -> bool:
+    """True for cleaned names with no usable referent.
+
+    Bare pronouns ("it", "they") refer only within their source document;
+    preposition-led multi-word names ("over two hundred mile per hour") are
+    adverbial/measure phrases, not entities.
+    """
+    words = name.split()
+    if not words:
+        return True
+    if len(words) == 1:
+        return words[0] in _PRONOUNS
+    return words[0] in _PREPOSITIONS
+
+
 def normalize_entities(entities: list[dict], text: str) -> list[dict]:
-    """Normalize entity names: lowercase, lemmatize, deduplicate.
+    """Normalize entity names: lowercase, strip determiners, lemmatize,
+    reject junk, deduplicate.
 
     Args:
         entities: List of entity dicts with name, type, start, end fields.
@@ -79,7 +254,10 @@ def normalize_entities(entities: list[dict], text: str) -> list[dict]:
         if not name:
             continue
 
-        norm_name = _lemmatize_name(name.lower(), original_name=name)
+        norm_name = clean_entity_name(name.lower(), original_name=name)
+        if not norm_name or is_junk_entity_name(norm_name):
+            logger.debug("Dropping junk entity name: %r", name)
+            continue
 
         normalized.append(
             {

--- a/src/hermes/name_normalizer.py
+++ b/src/hermes/name_normalizer.py
@@ -154,6 +154,35 @@ _PREPOSITIONS = {
     "without",
 }
 
+# Single-word names that are pure prepositions — never nouns in their own
+# right — are junk ("of", "with").  Deliberately a subset of _PREPOSITIONS:
+# homographs that work as standalone nouns/concepts ("outside", "past",
+# "above") are kept.
+_PURE_PREPOSITIONS = {
+    "amid",
+    "among",
+    "at",
+    "by",
+    "despite",
+    "during",
+    "except",
+    "for",
+    "from",
+    "in",
+    "into",
+    "of",
+    "onto",
+    "per",
+    "to",
+    "toward",
+    "towards",
+    "until",
+    "unto",
+    "upon",
+    "via",
+    "with",
+}
+
 
 def _lemmatize_word(word: str) -> str:
     """Singularize a single word via the shared core (hermes.canonical).
@@ -222,14 +251,15 @@ def is_junk_entity_name(name: str) -> bool:
     """True for cleaned names with no usable referent.
 
     Bare pronouns ("it", "they") refer only within their source document;
-    preposition-led multi-word names ("over two hundred mile per hour") are
+    bare pure prepositions ("of", "with") name nothing; preposition-led
+    multi-word names ("over two hundred mile per hour") are
     adverbial/measure phrases, not entities.
     """
     words = name.split()
     if not words:
         return True
     if len(words) == 1:
-        return words[0] in _PRONOUNS
+        return words[0] in _PRONOUNS or words[0] in _PURE_PREPOSITIONS
     return words[0] in _PREPOSITIONS
 
 

--- a/src/hermes/proposal_builder.py
+++ b/src/hermes/proposal_builder.py
@@ -41,12 +41,15 @@ def _normalize_edge_names(
 ) -> list[dict]:
     """Normalize edge endpoint names and drop edges with unresolvable endpoints.
 
-    Applies the same normalization pipeline (lowercase + lemmatize) to
-    edge endpoint names, then validates both endpoints exist in the
-    normalized entity set.  Edges referencing non-existent entities are
-    dropped with a warning — they would fail silently in Sophia anyway.
+    Applies the same cleaning pipeline as the entity set (lowercase +
+    determiner strip + lemmatize) to edge endpoint names, then validates
+    both endpoints exist in the normalized entity set.  Edges referencing
+    non-existent entities are dropped with a warning — they would fail
+    silently in Sophia anyway. Endpoints whose entity was rejected as junk
+    (pronouns, preposition-led phrases) fail the membership check and the
+    edge is dropped with them.
     """
-    from hermes.name_normalizer import _lemmatize_name
+    from hermes.name_normalizer import clean_entity_name
 
     known_names = {e["name"] for e in normalized_entities}
 
@@ -55,8 +58,8 @@ def _normalize_edge_names(
         edge = dict(edge)  # don't mutate originals
         src = edge.get("source_name", "")
         tgt = edge.get("target_name", "")
-        edge["source_name"] = _lemmatize_name(src.lower(), original_name=src)
-        edge["target_name"] = _lemmatize_name(tgt.lower(), original_name=tgt)
+        edge["source_name"] = clean_entity_name(src.lower(), original_name=src)
+        edge["target_name"] = clean_entity_name(tgt.lower(), original_name=tgt)
 
         if (
             edge["source_name"] not in known_names

--- a/src/hermes/proposal_builder.py
+++ b/src/hermes/proposal_builder.py
@@ -13,7 +13,11 @@ from datetime import UTC, datetime
 
 from hermes.combined_extractor import OpenAICombinedExtractor
 from hermes.embedding_provider import get_embedding_provider
-from hermes.name_normalizer import normalize_entities
+from hermes.name_normalizer import (
+    clean_entity_name,
+    is_junk_entity_name,
+    normalize_entities,
+)
 from hermes.ner_provider import get_ner_provider
 from hermes.relation_extractor import get_relation_extractor
 from hermes.services import generate_embeddings_batch
@@ -47,10 +51,8 @@ def _normalize_edge_names(
     non-existent entities are dropped with a warning — they would fail
     silently in Sophia anyway. Endpoints whose entity was rejected as junk
     (pronouns, preposition-led phrases) fail the membership check and the
-    edge is dropped with them.
+    edge is dropped with them at DEBUG, since the rejection was deliberate.
     """
-    from hermes.name_normalizer import clean_entity_name
-
     known_names = {e["name"] for e in normalized_entities}
 
     result: list[dict] = []
@@ -65,10 +67,22 @@ def _normalize_edge_names(
             edge["source_name"] not in known_names
             or edge["target_name"] not in known_names
         ):
-            logger.warning(
-                "Dropping edge %s -> %s: endpoint not in normalized entity set",
+            # An endpoint that cleaned to nothing or to a junk name was
+            # deliberately rejected upstream — that's routine, not a fault.
+            junk_endpoint = any(
+                not name or is_junk_entity_name(name)
+                for name in (edge["source_name"], edge["target_name"])
+            )
+            log = logger.debug if junk_endpoint else logger.warning
+            log(
+                "Dropping edge %s -> %s: %s",
                 edge["source_name"],
                 edge["target_name"],
+                (
+                    "junk-rejected endpoint"
+                    if junk_endpoint
+                    else "endpoint not in normalized entity set"
+                ),
             )
             continue
         result.append(edge)

--- a/tests/unit/test_jepa_integration.py
+++ b/tests/unit/test_jepa_integration.py
@@ -14,6 +14,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 torch = pytest.importorskip("torch")
+if not hasattr(torch, "Tensor"):
+    # A pruned venv can leave an orphaned namespace-package shell that
+    # imports as `torch` with no API; importorskip alone can't catch it.
+    pytest.skip(
+        "torch import is a namespace-package remnant, not a real install",
+        allow_module_level=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_name_normalizer.py
+++ b/tests/unit/test_name_normalizer.py
@@ -57,10 +57,14 @@ class TestSingularization:
         assert result[0]["name"] == "grass"
 
     def test_should_not_singularize_short_words(self):
-        """Words <= 2 chars should not be singularized."""
-        entities = [{"name": "us", "type": "entity", "start": 0, "end": 2}]
-        result = normalize_entities(entities, "us")
-        assert result[0]["name"] == "us"
+        """Words <= 2 chars should not be singularized.
+
+        Fixture is "ox", not "us": bare pronouns are now junk-rejected
+        (hermes#144), so "us" never reaches the singularization path.
+        """
+        entities = [{"name": "ox", "type": "entity", "start": 0, "end": 2}]
+        result = normalize_entities(entities, "ox")
+        assert result[0]["name"] == "ox"
 
     def test_should_not_singularize_non_plural_s(self):
         """Words like 'paris', 'diabetes' should not be singularized."""
@@ -272,3 +276,68 @@ class TestInvariantNouns:
         entities = [{"name": "chassis", "type": "entity", "start": 0, "end": 7}]
         result = normalize_entities(entities, "chassis")
         assert result[0]["name"] == "chassis"
+
+
+class TestDeterminerStripping:
+    def test_strips_leading_indefinite_article(self):
+        entities = [
+            {"name": "a slow delivery truck", "type": "entity", "start": 0, "end": 21}
+        ]
+        result = normalize_entities(entities, "a slow delivery truck")
+        assert result[0]["name"] == "slow delivery truck"
+
+    def test_strips_leading_definite_article(self):
+        entities = [
+            {"name": "The Morning Light", "type": "entity", "start": 0, "end": 17}
+        ]
+        result = normalize_entities(entities, "The Morning Light")
+        assert result[0]["name"] == "morning light"
+
+    def test_strips_possessive_determiner(self):
+        entities = [{"name": "its jaw", "type": "entity", "start": 0, "end": 7}]
+        result = normalize_entities(entities, "its jaw")
+        assert result[0]["name"] == "jaw"
+
+    def test_dedups_after_determiner_strip(self):
+        entities = [
+            {"name": "the acorn", "type": "entity", "start": 0, "end": 9},
+            {"name": "acorn", "type": "entity", "start": 20, "end": 25},
+        ]
+        result = normalize_entities(entities, "the acorn fell near an acorn")
+        assert len(result) == 1
+        assert result[0]["name"] == "acorn"
+
+
+class TestJunkRejection:
+    def test_drops_bare_pronoun(self):
+        entities = [{"name": "it", "type": "entity", "start": 0, "end": 2}]
+        assert normalize_entities(entities, "it") == []
+
+    def test_drops_capitalized_pronoun(self):
+        entities = [{"name": "They", "type": "entity", "start": 0, "end": 4}]
+        assert normalize_entities(entities, "They") == []
+
+    def test_drops_name_that_is_only_a_determiner(self):
+        entities = [{"name": "the", "type": "entity", "start": 0, "end": 3}]
+        assert normalize_entities(entities, "the") == []
+
+    def test_drops_leading_preposition_phrase(self):
+        entities = [
+            {
+                "name": "over two hundred miles per hour",
+                "type": "concept",
+                "start": 0,
+                "end": 31,
+            }
+        ]
+        assert normalize_entities(entities, "over two hundred miles per hour") == []
+
+    def test_keeps_single_common_noun(self):
+        entities = [{"name": "suv", "type": "entity", "start": 0, "end": 3}]
+        result = normalize_entities(entities, "suv")
+        assert result[0]["name"] == "suv"
+
+    def test_keeps_single_word_even_if_preposition_homograph(self):
+        entities = [{"name": "outside", "type": "concept", "start": 0, "end": 7}]
+        result = normalize_entities(entities, "outside")
+        assert result[0]["name"] == "outside"

--- a/tests/unit/test_name_normalizer.py
+++ b/tests/unit/test_name_normalizer.py
@@ -341,3 +341,11 @@ class TestJunkRejection:
         entities = [{"name": "outside", "type": "concept", "start": 0, "end": 7}]
         result = normalize_entities(entities, "outside")
         assert result[0]["name"] == "outside"
+
+    def test_drops_single_word_pure_preposition(self):
+        entities = [{"name": "of", "type": "entity", "start": 0, "end": 2}]
+        assert normalize_entities(entities, "of") == []
+
+    def test_drops_single_word_pure_preposition_with(self):
+        entities = [{"name": "with", "type": "entity", "start": 0, "end": 4}]
+        assert normalize_entities(entities, "with") == []

--- a/tests/unit/test_proposal_builder.py
+++ b/tests/unit/test_proposal_builder.py
@@ -334,3 +334,46 @@ class TestNormalizeEdgeNames:
         assert len(result) == 1
         assert result[0]["source_name"] == "morning light"
         assert result[0]["target_name"] == "meadow"
+
+    def test_junk_endpoint_edge_dropped_at_debug_not_warning(self):
+        from unittest.mock import patch
+
+        import hermes.proposal_builder as pb
+        from hermes.name_normalizer import normalize_entities
+        from hermes.proposal_builder import _normalize_edge_names
+
+        entities = normalize_entities(
+            [
+                {"name": "it", "type": "entity", "start": 0, "end": 2},
+                {"name": "a meadow", "type": "entity", "start": 9, "end": 17},
+            ],
+            "it fills a meadow",
+        )
+        edges = [{"source_name": "it", "target_name": "a meadow", "relation": "FILLS"}]
+        with (
+            patch.object(pb.logger, "debug") as mock_debug,
+            patch.object(pb.logger, "warning") as mock_warning,
+        ):
+            result = _normalize_edge_names(edges, entities)
+        assert result == []
+        mock_warning.assert_not_called()
+        assert any(
+            "junk-rejected endpoint" in str(call.args)
+            for call in mock_debug.call_args_list
+        )
+
+    def test_missing_endpoint_edge_dropped_at_warning(self):
+        from unittest.mock import patch
+
+        import hermes.proposal_builder as pb
+        from hermes.proposal_builder import _normalize_edge_names
+
+        entities = [{"name": "meadow", "type": "entity", "start": 0, "end": 6}]
+        edges = [{"source_name": "truck", "target_name": "meadow", "relation": "NEAR"}]
+        with patch.object(pb.logger, "warning") as mock_warning:
+            result = _normalize_edge_names(edges, entities)
+        assert result == []
+        assert any(
+            "not in normalized entity set" in str(call.args)
+            for call in mock_warning.call_args_list
+        )

--- a/tests/unit/test_proposal_builder.py
+++ b/tests/unit/test_proposal_builder.py
@@ -309,3 +309,28 @@ class TestProposalBuilder:
         assert proposal["proposed_nodes"][0]["name"] == "alice"
         assert proposal["proposed_nodes"][1]["name"] == "google"
         assert proposal["metadata"]["pipeline"]["ner_provider"] == "combined"
+
+
+class TestNormalizeEdgeNames:
+    def test_edge_endpoints_cleaned_to_match_stripped_entities(self):
+        from hermes.name_normalizer import normalize_entities
+        from hermes.proposal_builder import _normalize_edge_names
+
+        entities = normalize_entities(
+            [
+                {"name": "The Morning Light", "type": "entity", "start": 0, "end": 17},
+                {"name": "a meadow", "type": "entity", "start": 24, "end": 32},
+            ],
+            "The Morning Light fills a meadow",
+        )
+        edges = [
+            {
+                "source_name": "The Morning Light",
+                "target_name": "a meadow",
+                "relation": "FILLS",
+            }
+        ]
+        result = _normalize_edge_names(edges, entities)
+        assert len(result) == 1
+        assert result[0]["source_name"] == "morning light"
+        assert result[0]["target_name"] == "meadow"


### PR DESCRIPTION
The proposal path's `normalize_entities` lowercased and lemmatized but let determiners, bare pronouns, and adverbial/measure phrases through as node names — `a slow delivery truck`, `it`, `over two hundred miles per hour` all landed in the graph (hermes#144, observed live 2026-06-11).

**Changes**
- `clean_entity_name`: leading-determiner strip + lemmatize, shared by `normalize_entities` and `proposal_builder._normalize_edge_names` so edge endpoints keep matching their cleaned entities.
- `is_junk_entity_name`: rejects bare pronouns and preposition-led multi-word names; edges to rejected entities drop via the existing endpoint-membership check.
- `test_jepa_integration`: module-level skip when `torch` resolves to a namespace-package remnant that `importorskip` can't catch (was 7 fail/error in pruned venvs).
- `TestSingularization` short-word fixture `us` → `ox` (`us` is now correctly junk-rejected as a pronoun).

**Validation**
- TDD: 11 new unit tests written first and watched fail; full unit suite 373 passed / 2 skipped / 1 xfailed. ruff, black, mypy clean on touched files.
- Live smoke (16-block corpus through the running stack): pre-fix graph had determiner/pronoun/preposition junk; post-fix graph has **0** leading-determiner names, **0** bare pronouns, **0** preposition-led phrases (47 vs 51 data nodes — the delta is the rejected junk).

**Known limitation (tracked in #144):** adverb-led phrases (`late into the night`) survive — distinguishing those needs POS tagging, deliberately out of scope for this pass.

Fixes #144