### PR TITLE
fix(hermes#148): free entity typing — drop the type constraint from the extraction prompt

### DIFF
--- a/src/hermes/combined_extractor.py
+++ b/src/hermes/combined_extractor.py
@@ -16,8 +16,7 @@ import re
 from typing import Any
 
 
-from hermes.ner_provider import ONTOLOGY_TYPES, OpenAINERProvider
-from hermes.ontology_client import fetch_type_list, get_sophia_url
+from hermes.ner_provider import OpenAINERProvider
 from hermes.relation_extractor import OpenAIRelationExtractor
 
 logger = logging.getLogger(__name__)
@@ -36,28 +35,17 @@ class OpenAICombinedExtractor:
 
     name: str = "combined"
 
-    def _build_system_prompt(
-        self,
-        type_list: list[dict] | None = None,
-    ) -> str:
-        """Build the system prompt, optionally using dynamic type lists."""
-        if type_list is not None:
-            entity_types_section = "\n".join(
-                f"- {t['name']}: {t.get('description', '')}" for t in type_list
-            )
-            entity_types_section += "\nIf none of these types fit, use 'object'."
-        else:
-            entity_types_section = "\n".join(
-                f"- {t}: {desc}" for t, desc in ONTOLOGY_TYPES.items()
-            )
-
+    def _build_system_prompt(self) -> str:
+        """Build the system prompt. Entity types are NOT constrained: the
+        2026-06-11 ablation (hermes#148) measured any type list suppressing
+        type_accuracy ~4x and taxing entity/link F1 — and sophia classifies
+        via centroid proximity, ignoring the proposal type field, so the
+        constraint had no downstream consumer."""
         prompt = (
             "You are a combined named-entity recognition and relation extraction "
             "system for the LOGOS robotics ontology.\n\n"
             "Given input text, extract ALL named entities and ALL meaningful "
             "semantic relations between them in a SINGLE pass.\n\n"
-            "## Entity Types\n"
-            f"{entity_types_section}\n\n"
         )
 
         prompt += (
@@ -84,15 +72,15 @@ class OpenAICombinedExtractor:
             "with conjunctions like 'and', 'or', or commas into one name\n"
             "- Entity names must match the text exactly\n"
             "- start/end are character offsets into the input text\n"
-            "- Entity type must be one of the types listed above\n"
+            '- "type": a short lowercase category you choose for the entity\n'
             "- Prefer specific, contentful noun phrases; do NOT extract bare "
             "adjectives, pronouns, sentence fragments, or generic standalone nouns "
             "(e.g. 'structure', 'system', 'thing', 'result'); use the canonical "
             "noun-phrase surface form\n"
-            "- Temporal entities (type 'state': dates/times): set \"value\" to a "
+            '- Temporal entities (dates/times): set "value" to a '
             "normalized form, ISO-8601 where possible ('1943'->'1943', "
             "'March 1898'->'1898-03', 'the 1950s'->'195X'); \"unit\" is null\n"
-            "- Quantitative entities (type 'data': measurements/quantities): set "
+            "- Quantitative entities (measurements/quantities): set "
             '"value" to the numeric magnitude and "unit" to the unit '
             "('10 km'->10/'km'; '5 mg'->5/'mg'); plain counts: \"unit\" is null\n"
             '- All other entities: "value" and "unit" are null\n'
@@ -166,9 +154,7 @@ class OpenAICombinedExtractor:
         """
         from hermes.llm import generate_completion
 
-        sophia_url = get_sophia_url()
-        type_list = await fetch_type_list(sophia_url)
-        system_prompt = self._build_system_prompt(type_list)
+        system_prompt = self._build_system_prompt()
 
         messages = [
             {"role": "system", "content": system_prompt},
@@ -188,11 +174,9 @@ class OpenAICombinedExtractor:
 
         content = result.get("choices", [{}])[0].get("message", {}).get("content", "")
 
-        valid_types: set[str] | None = None
-        if type_list is not None:
-            valid_types = {t["name"] for t in type_list}
-
-        return self._parse_combined_response(content, text, valid_types=valid_types)
+        # Free typing (hermes#148): the extractor's chosen categories pass
+        # through unfiltered; sophia classifies by centroid.
+        return self._parse_combined_response(content, text)
 
     # -- Protocol compat: NERProvider ------------------------------------
 
@@ -220,8 +204,6 @@ class OpenAICombinedExtractor:
     def _parse_combined_response(
         content: str,
         original_text: str,
-        *,
-        valid_types: set[str] | None = None,
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         """Parse the combined JSON response into (entities, relations)."""
         data = _extract_json(content)
@@ -231,7 +213,7 @@ class OpenAICombinedExtractor:
         entities = OpenAINERProvider._parse_response(
             json.dumps({"entities": data.get("entities", [])}),
             original_text,
-            valid_types=valid_types,
+            coerce_unknown_types=False,
         )
 
         entity_names = {e["name"] for e in entities}

--- a/src/hermes/ner_provider.py
+++ b/src/hermes/ner_provider.py
@@ -180,6 +180,7 @@ class OpenAINERProvider:
         original_text: str,
         *,
         valid_types: set[str] | None = None,
+        coerce_unknown_types: bool = True,
     ) -> list[dict]:
         """Parse the LLM JSON response into entity dicts."""
         try:
@@ -205,10 +206,15 @@ class OpenAINERProvider:
             ent_type = ent.get("type", "entity")
             if not name:
                 continue
-            # Validate type — accept dynamic Sophia types or hardcoded fallback
-            allowed = valid_types if valid_types is not None else set(ONTOLOGY_TYPES)
-            if ent_type not in allowed:
-                ent_type = "entity"
+            # Validate type — accept dynamic Sophia types or hardcoded fallback.
+            # The combined path disables coercion entirely (hermes#148 free
+            # typing): the extractor's chosen category passes through.
+            if coerce_unknown_types:
+                allowed = (
+                    valid_types if valid_types is not None else set(ONTOLOGY_TYPES)
+                )
+                if ent_type not in allowed:
+                    ent_type = "entity"
             # Use provided offsets, or find them in the text.
             # Track search offset so repeated entities get distinct spans
             # instead of all mapping to the first occurrence.

--- a/src/hermes/ner_provider.py
+++ b/src/hermes/ner_provider.py
@@ -182,7 +182,17 @@ class OpenAINERProvider:
         valid_types: set[str] | None = None,
         coerce_unknown_types: bool = True,
     ) -> list[dict]:
-        """Parse the LLM JSON response into entity dicts."""
+        """Parse the LLM JSON response into entity dicts.
+
+        ``valid_types`` only participates when ``coerce_unknown_types`` is
+        True; combining a validation set with coercion disabled is a caller
+        bug and raises rather than silently discarding the set.
+        """
+        if valid_types is not None and not coerce_unknown_types:
+            raise ValueError(
+                "valid_types has no effect when coerce_unknown_types=False; "
+                "pass one or the other"
+            )
         try:
             data = json.loads(content)
         except json.JSONDecodeError:
@@ -206,6 +216,14 @@ class OpenAINERProvider:
             ent_type = ent.get("type", "entity")
             if not name:
                 continue
+            # Normalize the category defensively: the prompt asks for a short
+            # lowercase string, but the model may emit "Person", null, or a
+            # non-string. Lowercase strings; anything else falls back to
+            # "entity" so downstream consumers always see a lowercase str.
+            if isinstance(ent_type, str) and ent_type:
+                ent_type = ent_type.lower()
+            else:
+                ent_type = "entity"
             # Validate type — accept dynamic Sophia types or hardcoded fallback.
             # The combined path disables coercion entirely (hermes#148 free
             # typing): the extractor's chosen category passes through.

--- a/tests/unit/test_combined_extractor.py
+++ b/tests/unit/test_combined_extractor.py
@@ -7,12 +7,11 @@ from unittest.mock import AsyncMock, patch
 
 
 def _patch_ontology_client():
-    """Patch ontology client to return None (fallback to hardcoded types)."""
-    return patch(
-        "hermes.combined_extractor.fetch_type_list",
-        new_callable=AsyncMock,
-        return_value=None,
-    )
+    """No-op kept for call-site compatibility: the extractor no longer
+    consults the ontology client (hermes#148 — free typing)."""
+    from contextlib import nullcontext
+
+    return nullcontext()
 
 
 @pytest.mark.asyncio
@@ -261,70 +260,66 @@ class TestCombinedExtraction:
 
 
 @pytest.mark.asyncio
-class TestDynamicTypePrompt:
-    """Tests for dynamic type list injection into the system prompt."""
+class TestFreeTypingPrompt:
+    """The prompt must not constrain entity types (hermes#148).
 
-    async def test_dynamic_types_included_when_available(self):
-        from hermes.combined_extractor import OpenAICombinedExtractor
+    The 2026-06-11 ablation measured any type list in the prompt
+    suppressing type_accuracy ~4x (0.457 free vs ~0.12 constrained) and
+    taxing entity/link F1 — and sophia ignores the proposal type field
+    (centroid classification), so the constraint had no consumer.
+    """
 
-        extractor = OpenAICombinedExtractor()
-
-        fetched_types = [
-            {"name": "robot", "description": "an autonomous agent"},
-            {"name": "sensor", "description": "a sensing device"},
-        ]
-
-        llm_response = {
-            "choices": [
-                {"message": {"content": json.dumps({"entities": [], "relations": []})}}
-            ]
-        }
-
-        with (
-            patch(
-                "hermes.combined_extractor.fetch_type_list",
-                new_callable=AsyncMock,
-                return_value=fetched_types,
-            ),
-            patch(
-                "hermes.llm.generate_completion",
-                new_callable=AsyncMock,
-                return_value=llm_response,
-            ) as mock_llm,
-        ):
-            await extractor.extract_entities_and_relations("test")
-
-        system_msg = mock_llm.call_args[1]["messages"][0]["content"]
-        assert "- robot: an autonomous agent" in system_msg
-        assert "- sensor: a sensing device" in system_msg
-        assert "If none of these types fit, use 'object'." in system_msg
-
-    async def test_falls_back_to_hardcoded_when_fetch_returns_none(self):
+    async def test_prompt_has_no_entity_types_section(self):
         from hermes.combined_extractor import OpenAICombinedExtractor
         from hermes.ner_provider import ONTOLOGY_TYPES
 
-        extractor = OpenAICombinedExtractor()
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+        assert "## Entity Types" not in prompt
+        for type_name in ONTOLOGY_TYPES:
+            assert f"- {type_name}:" not in prompt
 
+    async def test_prompt_documents_free_type_field(self):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        prompt = OpenAICombinedExtractor()._build_system_prompt()
+        assert "category you choose" in prompt
+        assert "must be one of the types listed above" not in prompt
+
+    async def test_extraction_runs_without_ontology_client(self):
+        from hermes.combined_extractor import OpenAICombinedExtractor
+
+        extractor = OpenAICombinedExtractor()
         llm_response = {
             "choices": [
-                {"message": {"content": json.dumps({"entities": [], "relations": []})}}
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "entities": [
+                                    {
+                                        "name": "Bob",
+                                        "type": "person",
+                                        "start": 0,
+                                        "end": 3,
+                                    }
+                                ],
+                                "relations": [],
+                            }
+                        )
+                    }
+                }
             ]
         }
+        with patch(
+            "hermes.llm.generate_completion",
+            new_callable=AsyncMock,
+            return_value=llm_response,
+        ) as mock_llm:
+            entities, _ = await extractor.extract_entities_and_relations("Bob")
 
-        p1 = _patch_ontology_client()
-        with (
-            p1,
-            patch(
-                "hermes.llm.generate_completion",
-                new_callable=AsyncMock,
-                return_value=llm_response,
-            ) as mock_llm,
-        ):
-            await extractor.extract_entities_and_relations("test")
-
+        assert entities[0]["type"] == "person"
         system_msg = mock_llm.call_args[1]["messages"][0]["content"]
-        for type_name, desc in ONTOLOGY_TYPES.items():
-            assert f"- {type_name}: {desc}" in system_msg
+        assert "## Entity Types" not in system_msg
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_combined_extractor.py
+++ b/tests/unit/test_combined_extractor.py
@@ -269,7 +269,7 @@ class TestFreeTypingPrompt:
     (centroid classification), so the constraint had no consumer.
     """
 
-    async def test_prompt_has_no_entity_types_section(self):
+    def test_prompt_has_no_entity_types_section(self):
         from hermes.combined_extractor import OpenAICombinedExtractor
         from hermes.ner_provider import ONTOLOGY_TYPES
 
@@ -278,7 +278,7 @@ class TestFreeTypingPrompt:
         for type_name in ONTOLOGY_TYPES:
             assert f"- {type_name}:" not in prompt
 
-    async def test_prompt_documents_free_type_field(self):
+    def test_prompt_documents_free_type_field(self):
         from hermes.combined_extractor import OpenAICombinedExtractor
 
         prompt = OpenAICombinedExtractor()._build_system_prompt()

--- a/tests/unit/test_ner_provider.py
+++ b/tests/unit/test_ner_provider.py
@@ -198,6 +198,48 @@ class TestParseResponse:
         assert result[0]["start"] == 0
         assert result[0]["end"] == 5
 
+    def test_mixed_case_type_lowercased_under_free_typing(self):
+        from hermes.ner_provider import OpenAINERProvider
+
+        content = (
+            '{"entities": [{"name": "Ada", "type": "Person", "start": 0, "end": 3}]}'
+        )
+        result = OpenAINERProvider._parse_response(
+            content, "Ada codes", coerce_unknown_types=False
+        )
+        assert result[0]["type"] == "person"
+
+    def test_null_type_falls_back_to_entity_under_free_typing(self):
+        from hermes.ner_provider import OpenAINERProvider
+
+        content = '{"entities": [{"name": "Ada", "type": null, "start": 0, "end": 3}]}'
+        result = OpenAINERProvider._parse_response(
+            content, "Ada codes", coerce_unknown_types=False
+        )
+        assert result[0]["type"] == "entity"
+
+    def test_non_string_type_falls_back_to_entity(self):
+        from hermes.ner_provider import OpenAINERProvider
+
+        content = '{"entities": [{"name": "Ada", "type": 7, "start": 0, "end": 3}]}'
+        result = OpenAINERProvider._parse_response(
+            content, "Ada codes", coerce_unknown_types=False
+        )
+        assert result[0]["type"] == "entity"
+
+    def test_valid_types_with_coercion_disabled_raises(self):
+        import pytest
+
+        from hermes.ner_provider import OpenAINERProvider
+
+        with pytest.raises(ValueError, match="valid_types has no effect"):
+            OpenAINERProvider._parse_response(
+                '{"entities": []}',
+                "",
+                valid_types={"person"},
+                coerce_unknown_types=False,
+            )
+
 
 class TestNERDetectBackend:
     """Tests for _detect_backend and get_ner_provider factory."""


### PR DESCRIPTION
The 2026-06-11 full-factorial ablation (`results_20260611_ablation_matrix.json`, analysis on #148) measured the type list in the extraction prompt suppressing type_accuracy ~4× — any list, hardcoded defaults or live skeleton types — while taxing entity_f1 and link_f1. Downstream, sophia classifies via centroid proximity and ignores the proposal type field, so the constraint had no consumer.

**Changes**
- `_build_system_prompt`: Entity Types section removed; `type` documented as a category the model chooses; value/unit rules de-anchored from type labels (`'state'`/`'data'`)
- extract path: no `fetch_type_list` call, no valid-types post-filter; `ner_provider._parse_response` gains `coerce_unknown_types` (combined path passes False; legacy callers unchanged)
- `ner_provider`'s own (documented-deprecated) prompt path deliberately untouched
- `TestDynamicTypePrompt` → `TestFreeTypingPrompt`; the ontology-client patch helper is now a no-op kept for call sites

**Validation — production template, gold n=40, K=3 means (old = deployed prompt with live registry types):**

| metric | old | new | Δ |
|---|---|---|---|
| **type_accuracy** | 0.103 | **0.615** | **+0.512 (6×)** |
| entity_f1 | 0.750 | 0.770 | +0.020 |
| entity_recall | 0.772 | 0.778 | +0.006 |
| label_f1 | 0.164 | 0.180 | +0.016 |
| link_f1 | 0.384 | 0.349 | −0.035 |
| link_recall | 0.421 | 0.366 | −0.055 |
| df1_fraction | 0.608 | 0.688 | +0.080 |

Free typing inside the full production prompt beats even the ablation's bare-prompt ceiling (0.457). The link-metric dips and df1 rise are within the day's measured run-to-run bands (link_f1 spread to 0.058; df1 0.55–0.89 across today's runs) but worth watching at the next K=3 row; the H5 known-relations section is untouched by this PR.

Unit suite 376 passed / 1 xfailed; ruff/black/mypy clean. TDD red→green (the new free-typing test caught a residual coercion in the shared parser that the prompt-only change missed).

Note: `combined_extractor.py` is also touched by #143 — whichever merges second may need a trivial rebase.

When the ontology holds fine MINTED types (the relational-induction workstream), types can return to the prompt as advisory, information-ranked content — explicitly out of scope here.

Fixes #148