### PR TITLE
fix(type_cluster): mint specific types instead of reusing the domain root

### DIFF
--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1794,15 +1794,16 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         "- `outliers`: the EXACT names of members that are clearly NOT a kind of "
         "`name` (e.g. a measurement, equation, or property mixed into a cluster "
         "of objects). When in doubt, KEEP the member.\n"
-        "Examples (members -> JSON):\n"
-        "albert einstein; marie curie; isaac newton -> "
+        "Examples:\n"
+        "Input:\n- albert einstein\n- marie curie\n- isaac newton\n"
         '{"name": "person", "parent": "entity", "outliers": []}\n'
-        "thermal energy; nuclear energy; kinetic energy -> "
+        "Input:\n- thermal energy\n- nuclear energy\n- kinetic energy\n"
         '{"name": "energy", "parent": "concept", "outliers": []}\n'
-        "saturn; pluto; titan; kuiper belt -> "
+        "Input:\n- saturn\n- pluto\n- titan\n- kuiper belt\n"
         '{"name": "astronomical object", "parent": "entity", "outliers": []}\n'
-        "royal albert bridge; high level bridge; maximum achievable span of bridge -> "
-        '{"name": "bridge", "parent": "structure", '
+        "Input:\n- royal albert bridge\n- high level bridge\n"
+        "- maximum achievable span of bridge\n"
+        '{"name": "bridge", "parent": "entity", '
         '"outliers": ["maximum achievable span of bridge"]}\n'
         "Return ONLY a JSON object: "
         '{"name": "<noun>", "parent": "<existing type>" or null, '
@@ -1813,8 +1814,9 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
     user_msg = (
         "These entities were grouped together (embedding-coarse cluster):\n"
         f"{members_block}\n\nType them: name the category that binds them "
-        "(reuse an existing type if one fits, else mint under the most "
-        "specific existing parent), and list any members that do not fit."
+        "(reuse a specific existing type if one fits — never a domain root, "
+        "else mint under the most specific existing parent), and list any "
+        "members that do not fit."
     )
 
     # Bounded response: one name + one parent + a short outlier list. The

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1778,17 +1778,33 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
     catalog_block, _alias_unused, _pub_unused, catalog_names = _build_catalog_context()
 
     system_msg = (
-        "You type a cluster of entities. You are given the cluster's members "
-        "and the existing type catalog. Choose FROM WHAT EXISTS: return the "
-        "most specific existing type that fits the WHOLE cluster as `name` "
-        "with `parent`: null (reuse it). If no existing type fits, mint a new "
-        "type: return the new `name` (a lowercase singular noun) and a NON-NULL "
-        "`parent` -- the most specific existing type to place it under, and when "
-        "nothing more specific fits, a domain root (entity, concept, or process). "
-        "A new `name` MUST have a parent (at minimum a domain root); `parent` is "
-        "null ONLY when `name` is an existing type you are reusing. Also return "
-        "`outliers`: the EXACT names of any listed members that do not belong "
-        "under `name`. Do not invent ids or chains. Return ONLY a JSON object: "
+        "You assign a cluster of entities to the MOST SPECIFIC category that "
+        "binds the WHOLE cluster. You are given the members and the existing "
+        "type catalog.\n"
+        "- The domain roots (entity, concept, process) are NEVER specific enough "
+        "as a `name`. If the most specific EXISTING type that fits the cluster is "
+        "only a root, you MUST MINT the specific shared category: return it as "
+        "`name` (a lowercase singular noun) with a NON-NULL `parent` -- the most "
+        "specific existing type that contains it, or a domain root when nothing "
+        "more specific exists. The member hints (in parentheses) usually name the "
+        "category; use them.\n"
+        "- Reuse an existing catalog type with `parent`: null ONLY when that type "
+        "is genuinely specific and fits the whole cluster. NEVER return a domain "
+        "root as `name`.\n"
+        "- `outliers`: the EXACT names of members that are clearly NOT a kind of "
+        "`name` (e.g. a measurement, equation, or property mixed into a cluster "
+        "of objects). When in doubt, KEEP the member.\n"
+        "Examples (members -> JSON):\n"
+        "albert einstein; marie curie; isaac newton -> "
+        '{"name": "person", "parent": "entity", "outliers": []}\n'
+        "thermal energy; nuclear energy; kinetic energy -> "
+        '{"name": "energy", "parent": "concept", "outliers": []}\n'
+        "saturn; pluto; titan; kuiper belt -> "
+        '{"name": "astronomical object", "parent": "entity", "outliers": []}\n'
+        "royal albert bridge; high level bridge; maximum achievable span of bridge -> "
+        '{"name": "bridge", "parent": "structure", '
+        '"outliers": ["maximum achievable span of bridge"]}\n'
+        "Return ONLY a JSON object: "
         '{"name": "<noun>", "parent": "<existing type>" or null, '
         '"outliers": ["<member name>", ...]}.'
     )

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -399,3 +399,19 @@ def test_domain_root_is_a_valid_name_reuse(monkeypatch):
     body = _post(_members(("i1", "fermentation"))).json()
     assert body["name"] == "process"
     assert body["parent"] is None
+
+
+# --------------------------------------------------------------------------
+# The system prompt must push the model to MINT a specific shared category
+# rather than reusing a domain root as the cluster `name`.
+# --------------------------------------------------------------------------
+
+
+def test_type_cluster_prompt_requires_minting_specific_type(monkeypatch):
+    fake = _make_completion(json.dumps({"name": "person", "parent": "entity"}))
+    monkeypatch.setattr(m, "generate_completion", fake)
+    _post(_members(("i1", "marie curie"), ("i2", "isaac newton")))
+    system = fake.last_messages[0]["content"].lower()
+    assert "never specific enough" in system          # roots-not-enough clause
+    assert "must mint" in system                       # mint instruction
+    assert "person" in system and "energy" in system   # few-shot examples present

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -410,7 +410,8 @@ def test_domain_root_is_a_valid_name_reuse(monkeypatch):
 def test_type_cluster_prompt_requires_minting_specific_type(monkeypatch):
     fake = _make_completion(json.dumps({"name": "person", "parent": "entity"}))
     monkeypatch.setattr(m, "generate_completion", fake)
-    _post(_members(("i1", "marie curie"), ("i2", "isaac newton")))
+    resp = _post(_members(("i1", "marie curie"), ("i2", "isaac newton")))
+    assert resp.status_code == 200
     system = fake.last_messages[0]["content"].lower()
     assert "never specific enough" in system          # roots-not-enough clause
     assert "must mint" in system                       # mint instruction


### PR DESCRIPTION
Fixes the `/type-cluster` under-typing root cause: on the live model (gpt-4.1) the naming step **satisfices by reusing the domain root** (`entity`/`concept`) for coherent clusters instead of minting the specific type — so ~92% of HCG entities never get a real type and re-running emergence barely drains them. Closes #152.

> ⚠️ **Stacked PR — based on another branch.** This branch is cut from `fix/type-cluster-require-domain-parent` (#151), **not** `main`, and composes with its "require a domain parent for new types" change. The PR base is set to that branch so the diff shows only this commit. **Retarget to `main` once #151 merges.**

### Change

`/type-cluster` system prompt now:
- declares the domain roots (`entity`/`concept`/`process`) are **never specific enough** as a `name` → the model MUST MINT the specific shared category (with a non-null parent);
- forbids returning a domain root as `name`;
- adds four worked few-shot examples (people → person, energy forms → energy, planets → astronomical object, bridges → bridge with an outlier);
- keeps `outliers` conservative (only clear non-members; keep borderline).

No change to the JSON contract (`name`/`parent`/`outliers`) or downstream parsing.

### Why a prompt fix, not a model downgrade

Validated offline on the real captured `entity`-pool clusters. **Downgrading the model does NOT fix it** — gpt-4o still punts to the root with the current prompt; the prompt is the robust lever:

| model | current prompt | this PR's prompt |
|---|---|---|
| gpt-4o-mini | mostly mints | mints |
| gpt-4o | **punts to root** | mints |
| gpt-4.1 (live) | **punts to root** | mints |

With this prompt, gpt-4.1 returns `person` / `energy` / `astronomical object` / `organism` / `bridge` across the same clusters that currently yield `entity`/`concept`. (A global `HERMES_LLM_MODEL` downgrade would also hit every other hermes LLM task, so it's the wrong lever even where it appears to work.)

### Test

Adds `test_type_cluster_prompt_requires_minting_specific_type` — asserts the mint-bias clause + few-shot examples are present in the system prompt sent to the LLM (via the existing `generate_completion` monkeypatch harness; no live calls). `pytest tests/test_type_cluster.py` → **30 passed**.

### How to verify end-to-end

Deploy this branch's hermes, then re-run a full type-emergence scan over the `entity` pool and confirm the junk drawer drains (currently ~3,284 entities under the `entity` root; expect coherent clusters to mint `person`/`energy`/`organism`/etc.).
