### PR TITLE
fix(type-cluster): reject domain roots used as a type name (parent-only)

### DIFF
--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1680,7 +1680,7 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
         entry_name = entry["name"]
         entry_root = entry["root"] or "?"
         tag = (
-            " [parent only]" if str(entry_name).strip().lower() in _DOMAIN_ROOTS else ""
+            " [parent only]" if canonicalize(str(entry_name)) in _DOMAIN_ROOTS else ""
         )
         line = f"  - {entry_name} (root: {entry_root}){tag}"
         lines.append(line)

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1592,6 +1592,9 @@ async def name_cluster(request: NameClusterRequest) -> NameClusterResponse:
 # minted in the current design, so it is excluded from the catalog as well.
 _STRUCTURAL_ROOTS: set[str] = {"node", "root"}
 _CATALOG_EXCLUDED: set[str] = _STRUCTURAL_ROOTS | {"cognition"}
+# Domain realm roots: valid ONLY as a `parent` of a new type, NEVER as a type
+# `name`/reuse target (typing a cluster AS a bare realm is not a type).
+_DOMAIN_ROOTS: set[str] = {"entity", "concept", "process"}
 
 # Over-specification ceiling (computed on the RAW name, pre-canonicalize).
 MAX_WORDS: int = 3
@@ -1669,13 +1672,17 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
     published_uuids = {e["uuid"] for e in entries}
     catalog_names = {canonicalize(str(e["name"])) for e in entries}
     lines = [
-        "PUBLISHED TYPE CATALOG (the existing types: reuse one as `name`, "
-        "or pick one as the `parent` of a new type):"
+        "PUBLISHED TYPE CATALOG (existing types -- reuse one as `name`, or pick "
+        "one as the `parent` of a new type). Entries tagged [parent only] are "
+        "domain roots: usable as a `parent`, NEVER as a `name`:"
     ]
     for entry in entries:
         entry_name = entry["name"]
         entry_root = entry["root"] or "?"
-        line = f"  - {entry_name} (root: {entry_root})"
+        tag = (
+            " [parent only]" if str(entry_name).strip().lower() in _DOMAIN_ROOTS else ""
+        )
+        line = f"  - {entry_name} (root: {entry_root}){tag}"
         lines.append(line)
     return "\n".join(lines), {}, published_uuids, catalog_names
 
@@ -1786,7 +1793,11 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         "`parent` -- the most specific existing type to place it under, and when "
         "nothing more specific fits, a domain root (entity, concept, or process). "
         "A new `name` MUST have a parent (at minimum a domain root); `parent` is "
-        "null ONLY when `name` is an existing type you are reusing. Also return "
+        "null ONLY when `name` is an existing type you are reusing. The domain "
+        "roots (entity, concept, process) are valid ONLY as a `parent`, NEVER as "
+        "a `name`: if nothing more specific than a realm fits, MINT a new "
+        "specific type under that realm -- do not reuse the realm as the name. "
+        "Also return "
         "`outliers`: the EXACT names of any listed members that do not belong "
         "under `name`. Do not invent ids or chains. Return ONLY a JSON object: "
         '{"name": "<noun>", "parent": "<existing type>" or null, '
@@ -1849,6 +1860,17 @@ async def type_cluster(request: TypeClusterRequest) -> TypeClusterResponse:
         raise HTTPException(
             status_code=502,
             detail="LLM returned an empty/uncanonicalizable cluster name",
+        )
+
+    # Domain realm roots (entity/concept/process) are valid only as a `parent`,
+    # never as a type `name`. Reusing one as the name would type the whole
+    # cluster as a bare realm -- or, against a positional in-pass catalog that
+    # omits a childless realm, mint a duplicate root. Reject so the cohort is
+    # left in the pool for the next pass instead of being silently mis-typed.
+    if name in _DOMAIN_ROOTS:
+        raise HTTPException(
+            status_code=502,
+            detail="LLM returned a domain root as the type name (parent-only)",
         )
 
     # parent: null => reuse `name`; else the existing type to graft under.

--- a/src/hermes/main.py
+++ b/src/hermes/main.py
@@ -1679,9 +1679,7 @@ def _build_catalog_context() -> tuple[str, dict[str, str], set[str], set[str]]:
     for entry in entries:
         entry_name = entry["name"]
         entry_root = entry["root"] or "?"
-        tag = (
-            " [parent only]" if canonicalize(str(entry_name)) in _DOMAIN_ROOTS else ""
-        )
+        tag = " [parent only]" if canonicalize(str(entry_name)) in _DOMAIN_ROOTS else ""
         line = f"  - {entry_name} (root: {entry_root}){tag}"
         lines.append(line)
     return "\n".join(lines), {}, published_uuids, catalog_names

--- a/tests/test_type_cluster.py
+++ b/tests/test_type_cluster.py
@@ -43,6 +43,21 @@ def _post(members, request_id="t::0"):
 # --------------------------------------------------------------------------
 
 
+def test_rejects_domain_root_as_name(monkeypatch):
+    """A domain realm root (entity/concept/process) is valid only as a `parent`,
+    never as the type `name`. Reusing one as `name` would type the whole cluster
+    as a bare realm (or mint a duplicate root), so it must be rejected with 502
+    -- the cluster is then left in the pool for the next pass, not mis-typed."""
+    for realm in ("entity", "concept", "process", "Entity", "PROCESS"):
+        monkeypatch.setattr(
+            m,
+            "generate_completion",
+            _make_completion(json.dumps({"name": realm, "parent": None})),
+        )
+        resp = _post(_members(("i1", "mitochondrion"), ("i2", "ribosome")))
+        assert resp.status_code == 502, f"{realm!r} should be rejected as a name"
+
+
 def test_names_the_cluster_and_canonicalizes(monkeypatch):
     monkeypatch.setattr(
         m, "generate_completion", _make_completion(json.dumps({"name": "Vehicles"}))
@@ -392,16 +407,21 @@ def test_domain_root_is_a_valid_parent(monkeypatch):
     assert body["parent"] == "entity"  # ordinary catalog citizen
 
 
-def test_domain_root_is_a_valid_name_reuse(monkeypatch):
+def test_domain_root_as_name_is_rejected_even_with_catalog(monkeypatch):
+    # Contract change: a domain root (entity/concept/process) is parent-only,
+    # never a `name`. Reusing one as the type name now 502s even with a catalog
+    # present -- previously this was accepted as a valid reuse, which typed the
+    # whole cluster as a bare realm (or, against a positional in-pass catalog,
+    # minted a duplicate root). The cohort is left in the pool for the next pass.
     monkeypatch.setattr(m, "_type_registry", _FakeRegistry())
     monkeypatch.setattr(
         m,
         "generate_completion",
         _make_completion(json.dumps({"name": "process", "parent": None})),
     )
-    body = _post(_members(("i1", "fermentation"))).json()
-    assert body["name"] == "process"
-    assert body["parent"] is None
+    resp = _post(_members(("i1", "fermentation")))
+    assert resp.status_code == 502
+    assert "domain root" in resp.json()["detail"].lower()
 
 
 def test_new_type_with_null_parent_is_502_when_catalog_present(monkeypatch):


### PR DESCRIPTION
Closes #156.

A domain realm root (`entity`/`concept`/`process`) is valid only as a `parent`, never as the verdict `name`. The handler only 502'd a *new* name with no valid parent; a domain root **is** in the catalog (a valid parent), so a `{name: <realm>, parent: null}` verdict passed as "reuse" → the whole cluster typed as a bare realm, or (against sophia emergence's positional in-pass catalog that omits a childless realm) a **duplicate root** minted. In a cellbio cold-start this no-op'd ~85/107 clusters.

## Fix
- `_DOMAIN_ROOTS = {entity, concept, process}`; reject (502) when the canonicalized verdict `name` is a domain root.
- Prompt: domain roots are `parent`-only, never a `name` — if nothing more specific than a realm fits, mint a new specific type under it.
- Catalog block tags domain-root entries `[parent only]`.

## Contract change (breaking)
A `{name: <realm>, parent: null}` verdict previously accepted as valid reuse now 502s. The old `test_domain_root_is_a_valid_name_reuse` is inverted to `test_domain_root_as_name_is_rejected_even_with_catalog`.

## Validated (cellbio E2E)
With the realm catalog present, `/type-cluster` success went **0% → 97%** (16/16 specific verdicts; the remaining 502s are now *correct* realm-root rejections → cluster left for the next pass); emergence minted **14 specific types** (was 0–2). 31 type-cluster tests green.
